### PR TITLE
Include connection type in action log prefix

### DIFF
--- a/backend/__tests__/classes/Connection.test.ts
+++ b/backend/__tests__/classes/Connection.test.ts
@@ -136,7 +136,7 @@ describe("Connection class", () => {
           (msg) => msg.includes("[ACTION:") && msg.includes("status"),
         );
         expect(actionLog).toBeDefined();
-        expect(actionLog).toContain(`[${type}]`);
+        expect(actionLog).toContain(`[ACTION:${type.toUpperCase()}:OK]`);
       }
     } finally {
       logger.info = originalInfo;

--- a/backend/classes/Connection.ts
+++ b/backend/classes/Connection.ts
@@ -104,7 +104,7 @@ export class Connection<T extends Record<string, any> = Record<string, any>> {
       ? colors.gray(JSON.stringify(sanitizedParams))
       : JSON.stringify(sanitizedParams);
 
-    const statusMessage = `[ACTION:${loggerResponsePrefix}]`;
+    const statusMessage = `[ACTION:${this.type.toUpperCase()}:${loggerResponsePrefix}]`;
     const messagePrefix = config.logger.colorize
       ? loggerResponsePrefix === "OK"
         ? colors.bgBlue(statusMessage)
@@ -121,7 +121,7 @@ export class Connection<T extends Record<string, any> = Record<string, any>> {
         : "";
 
     logger.info(
-      `${messagePrefix} ${actionName} (${duration}ms) [${this.type}] ${method.length > 0 ? `[${method}]` : ""} ${this.identifier}${url.length > 0 ? `(${url})` : ""} ${error ? error : ""} ${loggingParams} ${errorStack}`,
+      `${messagePrefix} ${actionName} (${duration}ms) ${method.length > 0 ? `[${method}]` : ""} ${this.identifier}${url.length > 0 ? `(${url})` : ""} ${error ? error : ""} ${loggingParams} ${errorStack}`,
     );
 
     return { response, error };


### PR DESCRIPTION
## Summary
- Moves the connection type (web, cli, websocket, etc.) into the `[ACTION:...]` status prefix so logs read `[ACTION:WEB:OK]` instead of `[ACTION:OK] ... [web]`
- Removes the now-redundant separate `[type]` bracket from the log line
- Makes it easier to grep/filter logs by both connection type and status in a single token

## Test plan
- [x] Updated existing connection type logging test to assert the new format
- [x] `bun test __tests__/classes/Connection.test.ts` — 19/19 pass
- [x] `bun test` full suite — 196/196 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)