### PR TITLE
Silence bootstrap hook output in local environments

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,8 +10,6 @@ set -e
 # Only run in Claude Code cloud environment
 # -----------------------------------------------------------------------------
 if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
-    echo "Not running in Claude Code cloud environment (CLAUDE_CODE_REMOTE != true)"
-    echo "Skipping bootstrap. Use 'docker compose up' for local development."
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Removes echo statements from `scripts/bootstrap.sh` when `CLAUDE_CODE_REMOTE` is not set
- Prevents the bootstrap hook's noisy output from overshadowing the global `check-sync.sh` hook message in local dev sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)