### PR TITLE
Add env setup docs for fresh worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A modern TypeScript framework built on Bun, spiritual successor to ActionHero. Monorepo with `backend/` (API server) and `frontend/` (Next.js app). The core idea: **Actions are the universal controller** - they serve as HTTP endpoints, WebSocket handlers, CLI commands, background tasks, and MCP tools simultaneously.
 
+## Environment Setup
+
+Backend requires a `backend/.env` file. In a fresh clone or new git worktree, copy from the example and adjust:
+
+```bash
+cp backend/.env.example backend/.env
+```
+
+The defaults in `.env.example` assume a local macOS PostgreSQL where your shell `$USER` is a superuser with no password (typical for Homebrew Postgres). If that matches your setup, no edits are needed.
+
+Similarly for frontend:
+
+```bash
+cp frontend/.env.example frontend/.env
+```
+
 ## Common Commands
 
 All commands from root unless noted. Backend tests require PostgreSQL (`bun` and `bun-test` databases) and Redis running locally.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,8 +20,8 @@ MCP_SERVER_ENABLED=true
 SESSION_TTL=86400000
 SESSION_COOKIE_NAME="__session"
 
-DATABASE_URL="postgres://postgres:postgres@localhost:5432/bun"
-DATABASE_URL_TEST="postgres://postgres:postgres@localhost:5432/bun-test"
+DATABASE_URL="postgres://$USER@localhost:5432/bun"
+DATABASE_URL_TEST="postgres://$USER@localhost:5432/bun-test"
 DATABASE_AUTO_MIGRATE=true
 
 REDIS_URL="redis://localhost:6379/0"


### PR DESCRIPTION
## Summary
- Add "Environment Setup" section to `CLAUDE.md` explaining how to create `.env` files from examples in fresh clones/worktrees
- Update `backend/.env.example` to use `$USER@localhost` (no password) instead of `postgres:postgres@localhost` to match typical macOS Homebrew Postgres setup

## Test plan
- [x] Backend tests pass (231/231) with the new `.env` defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)