### PR TITLE
Fix triple-colon typo in Redis default URL

### DIFF
--- a/backend/config/redis.ts
+++ b/backend/config/redis.ts
@@ -3,6 +3,6 @@ import { loadFromEnvIfSet } from "../util/config";
 export const configRedis = {
   connectionString: await loadFromEnvIfSet(
     "REDIS_URL",
-    "redis:://localhost:6379/0",
+    "redis://localhost:6379/0",
   ),
 };


### PR DESCRIPTION
## Summary
- Fixed typo in `backend/config/redis.ts` where the default Redis URL was `redis:://localhost:6379/0` (three colons) instead of `redis://localhost:6379/0`

Fixes #96

## Test plan
- [x] Verify the default URL is now valid (`redis://localhost:6379/0`)
- [ ] Run backend tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)