### PR TITLE
Add Secure and SameSite flags to session cookie

### DIFF
--- a/backend/servers/web.ts
+++ b/backend/servers/web.ts
@@ -543,8 +543,11 @@ const buildHeaders = (connection?: Connection) => {
   headers["Access-Control-Allow-Credentials"] = "true";
 
   if (connection) {
+    const secure = config.server.web.applicationUrl.startsWith("https")
+      ? "; Secure"
+      : "";
     headers["Set-Cookie"] =
-      `${config.session.cookieName}=${connection.id}; Max-Age=${config.session.ttl}; Path=/; HttpOnly`;
+      `${config.session.cookieName}=${connection.id}; Max-Age=${config.session.ttl}; Path=/; HttpOnly; SameSite=Lax${secure}`;
   }
 
   return headers;


### PR DESCRIPTION
## Summary
- Adds `SameSite=Lax` flag to session cookie to prevent CSRF attacks
- Conditionally adds `Secure` flag when `applicationUrl` starts with `https` (skipped in local dev over HTTP)
- No behavior change for existing local development setups

Fixes #84

## Test plan
- [x] All 234 backend tests pass
- [x] Lint and type-check pass
- [ ] Verify cookie flags in browser dev tools when running locally (should have `SameSite=Lax` but not `Secure`)
- [ ] Verify cookie flags when `APPLICATION_URL` is set to an `https://` URL (should have both flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)