### PR TITLE
Fix session TTL unit mismatch (ms → seconds)

### DIFF
--- a/backend/config/session.ts
+++ b/backend/config/session.ts
@@ -1,6 +1,6 @@
 import { loadFromEnvIfSet } from "../util/config";
 
 export const configSession = {
-  ttl: await loadFromEnvIfSet("SESSION_TTL", 1000 * 60 * 60 * 24), // one day, in seconds
+  ttl: await loadFromEnvIfSet("SESSION_TTL", 60 * 60 * 24), // one day, in seconds
   cookieName: await loadFromEnvIfSet("SESSION_COOKIE_NAME", "__session"),
 };

--- a/backend/initializers/oauth.ts
+++ b/backend/initializers/oauth.ts
@@ -442,19 +442,18 @@ async function handleToken(req: Request): Promise<Response> {
     scopes: [],
   };
 
-  const tokenTtl = Math.floor(config.session.ttl / 1000); // config.session.ttl is in ms
   await api.redis.redis.set(
     `oauth:token:${accessToken}`,
     JSON.stringify(tokenData),
     "EX",
-    tokenTtl,
+    config.session.ttl,
   );
 
   return new Response(
     JSON.stringify({
       access_token: accessToken,
       token_type: "Bearer",
-      expires_in: tokenTtl,
+      expires_in: config.session.ttl,
     }),
     {
       status: 200,


### PR DESCRIPTION
## Summary

- `config.session.ttl` was `1000 * 60 * 60 * 24` (86,400,000 ms) but Redis `EXPIRE`, cookie `Max-Age`, and OAuth `EX` all expect **seconds**
- Sessions/cookies persisted ~1000 days instead of 1 day — a critical security issue
- Changed default to `60 * 60 * 24` (86,400 seconds) and removed the now-unnecessary `/ 1000` workaround in OAuth token handling

## Test plan

- [x] Session initializer tests pass (14/14)
- [x] MCP/OAuth tests pass (26/26)
- [ ] Verify cookie `Max-Age` is 86400 in browser devtools after deploy

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)