### PR TITLE
Fix user enumeration in login via different error messages

### DIFF
--- a/backend/__tests__/actions/session.test.ts
+++ b/backend/__tests__/actions/session.test.ts
@@ -55,7 +55,7 @@ describe("session:create", () => {
     expect(response.error?.message).toEqual("This is not a valid email");
   });
 
-  test("fails when users is not found", async () => {
+  test("fails when user is not found with generic error", async () => {
     const res = await fetch(url + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -66,10 +66,10 @@ describe("session:create", () => {
     });
     const response = (await res.json()) as ActionResponse<SessionCreate>;
     expect(res.status).toBe(500);
-    expect(response.error?.message).toEqual("User not found");
+    expect(response.error?.message).toEqual("Invalid email or password");
   });
 
-  test("fails when passwords do not match", async () => {
+  test("fails when passwords do not match with same generic error", async () => {
     const res = await fetch(url + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -80,7 +80,7 @@ describe("session:create", () => {
     });
     const response = (await res.json()) as ActionResponse<SessionCreate>;
     expect(res.status).toBe(500);
-    expect(response.error?.message).toEqual("Password does not match");
+    expect(response.error?.message).toEqual("Invalid email or password");
   });
 });
 

--- a/backend/actions/session.ts
+++ b/backend/actions/session.ts
@@ -48,17 +48,12 @@ export class SessionCreate implements Action {
       .from(users)
       .where(eq(users.email, params.email));
 
-    if (!user) {
+    const passwordMatch = user
+      ? await checkPassword(user, params.password)
+      : false;
+    if (!user || !passwordMatch) {
       throw new TypedError({
-        message: "User not found",
-        type: ErrorType.CONNECTION_ACTION_RUN,
-      });
-    }
-
-    const passwordMatch = await checkPassword(user, params.password);
-    if (!passwordMatch) {
-      throw new TypedError({
-        message: "Password does not match",
+        message: "Invalid email or password",
         type: ErrorType.CONNECTION_ACTION_RUN,
       });
     }


### PR DESCRIPTION
## Problem

The login endpoint revealed whether an email address has an account by returning different error messages for "user not found" vs. "wrong password". This enables attackers to enumerate valid email addresses.

## Solution

Both failure cases now return a generic "Invalid email or password" message, matching the approach already used in the OAuth flow.

## Testing

Updated tests verify both error conditions return the same generic message. All session action tests pass.

Fixes #89