### PR TITLE
Add stricter rate limit for OAuth client registration

### DIFF
--- a/backend/config/rateLimit.ts
+++ b/backend/config/rateLimit.ts
@@ -9,4 +9,14 @@ export const configRateLimit = {
   unauthenticatedLimit: await loadFromEnvIfSet("RATE_LIMIT_UNAUTH_LIMIT", 20),
   authenticatedLimit: await loadFromEnvIfSet("RATE_LIMIT_AUTH_LIMIT", 200),
   keyPrefix: await loadFromEnvIfSet("RATE_LIMIT_KEY_PREFIX", "ratelimit"),
+  /** Stricter limit for OAuth client registration (per IP per window). */
+  oauthRegisterLimit: await loadFromEnvIfSet(
+    "RATE_LIMIT_OAUTH_REGISTER_LIMIT",
+    5,
+  ),
+  /** Window for OAuth registration rate limit (default: 1 hour). */
+  oauthRegisterWindowMs: await loadFromEnvIfSet(
+    "RATE_LIMIT_OAUTH_REGISTER_WINDOW_MS",
+    3_600_000,
+  ),
 };

--- a/backend/initializers/oauth.ts
+++ b/backend/initializers/oauth.ts
@@ -101,7 +101,16 @@ export class OAuthInitializer extends Initializer {
           path === "/oauth/authorize" ||
           path === "/oauth/token")
       ) {
-        const info = await checkRateLimit(`ip:${ip}`, false);
+        // /oauth/register gets a stricter, dedicated rate limit
+        const overrides =
+          path === "/oauth/register"
+            ? {
+                limit: config.rateLimit.oauthRegisterLimit,
+                windowMs: config.rateLimit.oauthRegisterWindowMs,
+                keyPrefix: `${config.rateLimit.keyPrefix}:oauth-register`,
+              }
+            : undefined;
+        const info = await checkRateLimit(`ip:${ip}`, false, overrides);
         if (info.retryAfter !== undefined) {
           return new Response(
             JSON.stringify({


### PR DESCRIPTION
## Summary

Closes #91

- Adds a **dedicated rate limit for `/oauth/register`** (5 requests per hour per IP), separate from the general rate limit (20/min)
- Uses its own Redis key namespace (`ratelimit:oauth-register:...`) so registration requests don't share quota with other endpoints
- Extends `checkRateLimit()` to accept optional overrides (limit, windowMs, keyPrefix) for reuse
- Configurable via `RATE_LIMIT_OAUTH_REGISTER_LIMIT` and `RATE_LIMIT_OAUTH_REGISTER_WINDOW_MS` env vars

## Test plan

- [x] New test: verifies registration is blocked after exceeding the stricter limit while other OAuth endpoints remain accessible
- [x] Existing rate limit middleware tests pass (no regression from `checkRateLimit` signature change)
- [x] Full MCP/OAuth test suite passes (34 tests)
- [x] Full backend test suite passes (265 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)