### PR TITLE
Validate WebSocket Origin header before upgrade to prevent CSWSH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,10 @@ Drizzle ORM table definitions. Migrations auto-apply on server start when `confi
 ### TypedError (`backend/classes/TypedError.ts`)
 All action errors must use `TypedError` with an `ErrorType` enum. Each error type maps to an HTTP status code via `ErrorStatusCodes`.
 
+## Coding Conventions
+
+- **No `as any`** — Never use `as any` type assertions. Use `@ts-expect-error` with an explanatory comment when the type system can't express something, or add a proper type/interface.
+
 ## Testing Patterns
 
 Tests use Bun's built-in test runner. Each test file boots/stops the full server:

--- a/backend/__tests__/servers/websocket-helpers.ts
+++ b/backend/__tests__/servers/websocket-helpers.ts
@@ -4,8 +4,10 @@ import { serverUrl } from "../setup";
 const wsUrl = () =>
   serverUrl().replace("https://", "wss://").replace("http://", "ws://");
 
-export const buildWebSocket = async () => {
-  const socket = new WebSocket(wsUrl());
+export const buildWebSocket = async (
+  options: { headers?: Record<string, string> } = {},
+) => {
+  const socket = new WebSocket(wsUrl(), { headers: options.headers });
   const messages: MessageEvent[] = [];
   socket.addEventListener("message", (event) => {
     messages.push(event);


### PR DESCRIPTION
Closes #83

Adds origin validation to reject WebSocket upgrade requests from disallowed origins, mitigating Cross-Site WebSocket Hijacking attacks.

**Changes:**
- Validate `Origin` header in `handleIncomingConnection()` before `server.upgrade()`
- Reject with 403 and error message if origin doesn't match `config.server.web.allowedOrigins`
- Support wildcard (`*`) and comma-separated origin lists
- Add comprehensive tests for allowed/rejected origins and wildcard config
- Document coding convention: no `as any` type assertions in CLAUDE.md

**Tests:** All 20 server tests pass (9 WebSocket + 11 HTTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)