### PR TITLE
Deny subscription to undefined PubSub channels

### DIFF
--- a/backend/initializers/channels.ts
+++ b/backend/initializers/channels.ts
@@ -2,6 +2,7 @@ import { api, logger } from "../api";
 import type { Channel } from "../classes/Channel";
 import type { Connection } from "../classes/Connection";
 import { Initializer } from "../classes/Initializer";
+import { ErrorType, TypedError } from "../classes/TypedError";
 import { globLoader } from "../util/glob";
 
 const namespace = "channels";
@@ -43,10 +44,11 @@ export class Channels extends Initializer {
   ): Promise<void> => {
     const channel = this.findChannel(channelName);
 
-    // If no channel definition exists, allow subscription by default
-    // This maintains backwards compatibility
     if (!channel) {
-      return;
+      throw new TypedError({
+        message: `Channel not found: ${channelName}`,
+        type: ErrorType.CONNECTION_CHANNEL_AUTHORIZATION,
+      });
     }
 
     // Run all middleware runBefore hooks


### PR DESCRIPTION
## Summary

Implements deny-by-default security for PubSub channel subscriptions (fixes #86). Channels must now be explicitly defined via the `backend/channels/` directory to be subscribable. Previously, any undefined channel would silently allow subscriptions, bypassing authorization checks.

## Changes

- **authorizeSubscription**: Throws `CONNECTION_CHANNEL_AUTHORIZATION` error when no Channel definition matches the requested channel name
- **Tests**: Updated channel authorization tests to expect rejection of undefined channels; registered temporary test channels where needed to test subscription limits and presence cleanup

## Test Plan

- All 267 backend tests pass
- New deny-by-default behavior verified across channel auth, websocket, and presence tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)