### PR TITLE
Add configurable error stack traces in responses

### DIFF
--- a/backend/__tests__/servers/web.test.ts
+++ b/backend/__tests__/servers/web.test.ts
@@ -47,6 +47,20 @@ describe("actions", () => {
     expect(response.error?.message).toContain("Action not found");
     expect(response.error?.stack).toContain("/bun-actionhero/");
   });
+
+  test("error responses omit stack when includeStackInErrors is false", async () => {
+    const original = config.server.web.includeStackInErrors;
+    config.server.web.includeStackInErrors = false;
+    try {
+      const res = await fetch(url + "/api/non-existent-action");
+      expect(res.status).toBe(404);
+      const response = (await res.json()) as ActionResponse<Status>;
+      expect(response.error?.message).toContain("Action not found");
+      expect(response.error?.stack).toBeUndefined();
+    } finally {
+      config.server.web.includeStackInErrors = original;
+    }
+  });
 });
 
 describe("security headers", () => {

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -3,6 +3,7 @@ import { configLogger } from "./logger";
 import { configProcess } from "./process";
 import { configRateLimit } from "./rateLimit";
 import { configRedis } from "./redis";
+import { configServerCli } from "./server/cli";
 import { configServerMcp } from "./server/mcp";
 import { configServerWeb } from "./server/web";
 import { configSession } from "./session";
@@ -15,6 +16,6 @@ export const config = {
   redis: configRedis,
   rateLimit: configRateLimit,
   session: configSession,
-  server: { web: configServerWeb, mcp: configServerMcp },
+  server: { cli: configServerCli, web: configServerWeb, mcp: configServerMcp },
   tasks: configTasks,
 };

--- a/backend/config/server/cli.ts
+++ b/backend/config/server/cli.ts
@@ -1,0 +1,9 @@
+import { loadFromEnvIfSet } from "../../util/config";
+
+export const configServerCli = {
+  includeStackInErrors: await loadFromEnvIfSet(
+    "CLI_INCLUDE_STACK_IN_ERRORS",
+    true,
+  ),
+  quiet: await loadFromEnvIfSet("CLI_QUIET", false),
+};

--- a/backend/config/server/web.ts
+++ b/backend/config/server/web.ts
@@ -39,6 +39,10 @@ export const configServerWeb = {
     "WS_MAX_SUBSCRIPTIONS",
     100,
   ),
+  includeStackInErrors: await loadFromEnvIfSet(
+    "WEB_SERVER_INCLUDE_STACK_IN_ERRORS",
+    (Bun.env.NODE_ENV ?? "development") !== "production",
+  ),
   securityHeaders: {
     "Content-Security-Policy": await loadFromEnvIfSet(
       "WEB_SECURITY_CSP",

--- a/backend/servers/web.ts
+++ b/backend/servers/web.ts
@@ -701,7 +701,7 @@ function buildErrorPayload(error: TypedError) {
     timestamp: new Date().getTime(),
     key: error.key !== undefined ? error.key : undefined,
     value: error.value !== undefined ? error.value : undefined,
-    stack: error.stack,
+    ...(config.server.web.includeStackInErrors ? { stack: error.stack } : {}),
   };
 }
 

--- a/backend/util/cli.ts
+++ b/backend/util/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import os from "node:os";
 import { Action, api, Connection, RUN_MODE } from "../api";
+import { config } from "../config";
 import { ExitCode } from "./../classes/ExitCode";
 import { TypedError } from "./../classes/TypedError";
 
@@ -49,7 +50,7 @@ The server will be initialized and started, except for initialized with the skip
 
 async function runActionViaCLI(options: Record<string, string>, command: any) {
   const actionName: string = command.parent.args[0];
-  if (options.quiet) api.logger.quiet = true;
+  if (options.quiet || config.server.cli.quiet) api.logger.quiet = true;
 
   await api.initialize();
 
@@ -76,10 +77,12 @@ async function runActionViaCLI(options: Record<string, string>, command: any) {
     if (error instanceof TypedError) {
       payload.error = {
         message: error.message,
-        stack: error.stack,
         type: error.type,
         key: error.key,
         value: error.value,
+        ...(config.server.cli.includeStackInErrors
+          ? { stack: error.stack }
+          : {}),
       };
     } else {
       payload.error = error;


### PR DESCRIPTION
## Summary

Addresses #82 with proper config-driven error response handling instead of hardcoded NODE_ENV checks. Introduces:

- **Web server**: `WEB_SERVER_INCLUDE_STACK_IN_ERRORS` env var (defaults to `true` in dev/test, `false` in production)
- **CLI**: `CLI_INCLUDE_STACK_IN_ERRORS` env var (defaults to `true` — better for local debugging) and `CLI_QUIET` env var (defaults to `false`, can be overridden by `--quiet` flag)

## Test plan

- [x] Existing error response test still passes with default settings
- [x] New test verifies stack is omitted when config is disabled
- [x] All 12 web server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)