### PR TITLE
Fix CORS wildcard + credentials spec violation

### DIFF
--- a/backend/__tests__/servers/web.test.ts
+++ b/backend/__tests__/servers/web.test.ts
@@ -81,6 +81,83 @@ describe("security headers", () => {
   });
 });
 
+describe("CORS headers", () => {
+  test("wildcard allowedOrigins without Origin header returns * and no credentials", async () => {
+    const original = config.server.web.allowedOrigins;
+    (config.server.web as any).allowedOrigins = "*";
+    try {
+      const res = await fetch(url + "/api/status");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    } finally {
+      (config.server.web as any).allowedOrigins = original;
+    }
+  });
+
+  test("wildcard allowedOrigins with Origin header reflects origin and sets credentials", async () => {
+    const original = config.server.web.allowedOrigins;
+    (config.server.web as any).allowedOrigins = "*";
+    try {
+      const res = await fetch(url + "/api/status", {
+        headers: { Origin: "http://example.com" },
+      });
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "http://example.com",
+      );
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+      expect(res.headers.get("Vary")).toContain("Origin");
+    } finally {
+      (config.server.web as any).allowedOrigins = original;
+    }
+  });
+
+  test("specific allowedOrigins with matching Origin reflects origin and sets credentials", async () => {
+    const original = config.server.web.allowedOrigins;
+    (config.server.web as any).allowedOrigins = "http://allowed.example.com";
+    try {
+      const res = await fetch(url + "/api/status", {
+        headers: { Origin: "http://allowed.example.com" },
+      });
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "http://allowed.example.com",
+      );
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+      expect(res.headers.get("Vary")).toContain("Origin");
+    } finally {
+      (config.server.web as any).allowedOrigins = original;
+    }
+  });
+
+  test("specific allowedOrigins with non-matching Origin omits credentials", async () => {
+    const original = config.server.web.allowedOrigins;
+    (config.server.web as any).allowedOrigins = "http://allowed.example.com";
+    try {
+      const res = await fetch(url + "/api/status", {
+        headers: { Origin: "http://evil.example.com" },
+      });
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    } finally {
+      (config.server.web as any).allowedOrigins = original;
+    }
+  });
+
+  test("OPTIONS preflight with Origin reflects origin", async () => {
+    const original = config.server.web.allowedOrigins;
+    (config.server.web as any).allowedOrigins = url;
+    try {
+      const res = await fetch(url + "/api/status", {
+        method: "OPTIONS",
+        headers: { Origin: url },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(url);
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    } finally {
+      (config.server.web as any).allowedOrigins = original;
+    }
+  });
+});
+
 describe("cookies", () => {
   test("session cookie uses SameSite=Strict", async () => {
     const res = await fetch(url + "/api/status");


### PR DESCRIPTION
## Summary

Closes #80.

- **`backend/servers/web.ts`**: `buildHeaders()` now dynamically reflects the request `Origin` header when it matches the configured allowlist, and only sets `Access-Control-Allow-Credentials: true` in that case. When no `Origin` is present and config is `*`, sends `Access-Control-Allow-Origin: *` without credentials. Adds `Vary: Origin` for correct cache behavior.
- **`backend/initializers/mcp.ts`**: Same dynamic CORS logic applied to the MCP endpoint's `corsHeaders`.
- **`backend/__tests__/servers/web.test.ts`**: 5 new tests covering wildcard ± origin, specific origin match/mismatch, and OPTIONS preflight.

## Test plan

- [x] All 275 existing tests pass
- [x] 5 new CORS tests verify correct header behavior
- [ ] Manual: verify `curl -H "Origin: http://example.com"` reflects origin with credentials
- [ ] Manual: verify `curl` without Origin header returns `*` without credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)