### PR TITLE
Fix CI: update stale bun-actionhero reference in test

### DIFF
--- a/backend/__tests__/servers/web.test.ts
+++ b/backend/__tests__/servers/web.test.ts
@@ -45,7 +45,7 @@ describe("actions", () => {
     expect(res.status).toBe(404);
     const response = (await res.json()) as ActionResponse<Status>;
     expect(response.error?.message).toContain("Action not found");
-    expect(response.error?.stack).toContain("/bun-actionhero/");
+    expect(response.error?.stack).toContain("/keryx/");
   });
 
   test("error responses omit stack when includeStackInErrors is false", async () => {


### PR DESCRIPTION
## Summary
- The Keryx rename (#120) missed one test assertion in `web.test.ts` that still checked for `/bun-actionhero/` in error stack traces
- Updated to `/keryx/` to match the new repo name

## Test plan
- [x] `bun test __tests__/servers/web.test.ts` passes locally (17/17)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)