### PR TITLE
Add security docs and update guides for recent security features

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,6 +38,7 @@ export default defineConfig({
         {
           text: "Usage",
           items: [
+            { text: "Security", link: "/guide/security" },
             { text: "Testing", link: "/guide/testing" },
             { text: "Deployment", link: "/guide/deployment" },
           ],

--- a/docs/guide/channels.md
+++ b/docs/guide/channels.md
@@ -96,3 +96,29 @@ await api.pubsub.broadcast(
 ```
 
 Messages go through Redis PubSub, so they work across server instances. If you're running three backend processes behind a load balancer, a broadcast from one reaches subscribers on all three.
+
+## WebSocket Security
+
+Channels and WebSocket connections have several built-in protections. See the [Security guide](/guide/security) for the full picture.
+
+### Channel Name Validation
+
+Channel names must match `/^[a-zA-Z0-9:._-]{1,200}$/` — alphanumeric characters plus `:`, `.`, `_`, `-`, with a max length of 200. Invalid names are rejected before any subscription logic runs.
+
+### Undefined Channels
+
+If a client tries to subscribe to a channel name that doesn't match any registered channel, the subscription is denied with a `CHANNEL_NOT_FOUND` error. You must define a channel (exact or pattern) for every topic clients can subscribe to.
+
+### Origin Validation
+
+Before upgrading an HTTP connection to WebSocket, the server checks the `Origin` header against `config.server.web.allowedOrigins`. Requests from unrecognized origins are rejected, preventing Cross-Site WebSocket Hijacking (CSWSH).
+
+### Connection Limits
+
+Each WebSocket connection is subject to:
+
+- **Message size** — messages larger than `websocketMaxPayloadSize` (default 64 KB) are rejected
+- **Message rate** — clients sending more than `websocketMaxMessagesPerSecond` (default 20/s) are disconnected
+- **Subscription count** — each connection can subscribe to at most `websocketMaxSubscriptions` (default 100) channels
+
+All of these are configurable via environment variables. See [Configuration](/guide/config) for details.

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -16,11 +16,13 @@ backend/config/
 ├── database.ts     # Database connection string, auto-migrate flag
 ├── logger.ts       # Log level, timestamps, colors
 ├── process.ts      # Process name, shutdown timeout
+├── rateLimit.ts    # Rate limiting windows and thresholds
 ├── redis.ts        # Redis connection string
-├── session.ts      # Session TTL, cookie name
+├── session.ts      # Session TTL, cookie security flags
 ├── tasks.ts        # Task queue settings
 └── server/
-    ├── web.ts      # Web server port, host, CORS, static files
+    ├── cli.ts      # CLI error display, quiet mode
+    ├── web.ts      # Web server port, CORS, security headers, WS limits
     └── mcp.ts      # MCP server toggle, route, OAuth TTLs
 ```
 
@@ -82,10 +84,13 @@ The helper is also type-aware — it parses `"true"`/`"false"` strings into bool
 
 ### Session
 
-| Key          | Env Var               | Default                  |
-| ------------ | --------------------- | ------------------------ |
-| `ttl`        | `SESSION_TTL`         | `86400000` (1 day in ms) |
-| `cookieName` | `SESSION_COOKIE_NAME` | `"__session"`            |
+| Key              | Env Var                    | Default                    | Description                               |
+| ---------------- | -------------------------- | -------------------------- | ----------------------------------------- |
+| `ttl`            | `SESSION_TTL`              | `86400` (1 day in seconds) | Session lifetime                          |
+| `cookieName`     | `SESSION_COOKIE_NAME`      | `"__session"`              | Cookie name                               |
+| `cookieHttpOnly` | `SESSION_COOKIE_HTTP_ONLY` | `true`                     | Prevent JavaScript access                 |
+| `cookieSecure`   | `SESSION_COOKIE_SECURE`    | `false`                    | HTTPS-only cookies                        |
+| `cookieSameSite` | `SESSION_COOKIE_SAME_SITE` | `"Strict"`                 | CSRF protection (`Strict`, `Lax`, `None`) |
 
 ### Process
 
@@ -96,15 +101,33 @@ The helper is also type-aware — it parses `"true"`/`"false"` strings into bool
 
 ### Web Server
 
-| Key                  | Env Var                      | Default                   |
-| -------------------- | ---------------------------- | ------------------------- |
-| `enabled`            | `WEB_SERVER_ENABLED`         | `true`                    |
-| `port`               | `WEB_SERVER_PORT`            | `8080`                    |
-| `host`               | `WEB_SERVER_HOST`            | `"localhost"`             |
-| `applicationUrl`     | `APPLICATION_URL`            | `"http://localhost:8080"` |
-| `apiRoute`           | `WEB_SERVER_API_ROUTE`       | `"/api"`                  |
-| `allowedOrigins`     | `WEB_SERVER_ALLOWED_ORIGINS` | `"*"`                     |
-| `staticFilesEnabled` | `WEB_SERVER_STATIC_ENABLED`  | `true`                    |
+| Key                             | Env Var                              | Default                                          |
+| ------------------------------- | ------------------------------------ | ------------------------------------------------ |
+| `enabled`                       | `WEB_SERVER_ENABLED`                 | `true`                                           |
+| `port`                          | `WEB_SERVER_PORT`                    | `8080`                                           |
+| `host`                          | `WEB_SERVER_HOST`                    | `"localhost"`                                    |
+| `applicationUrl`                | `APPLICATION_URL`                    | `"http://localhost:8080"`                        |
+| `apiRoute`                      | `WEB_SERVER_API_ROUTE`               | `"/api"`                                         |
+| `allowedOrigins`                | `WEB_SERVER_ALLOWED_ORIGINS`         | `"*"`                                            |
+| `allowedMethods`                | `WEB_SERVER_ALLOWED_METHODS`         | `"HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS"` |
+| `allowedHeaders`                | `WEB_SERVER_ALLOWED_HEADERS`         | `"Content-Type"`                                 |
+| `staticFilesEnabled`            | `WEB_SERVER_STATIC_ENABLED`          | `true`                                           |
+| `includeStackInErrors`          | `WEB_SERVER_INCLUDE_STACK_IN_ERRORS` | `true` (dev) / `false` (prod)                    |
+| `websocketMaxPayloadSize`       | `WS_MAX_PAYLOAD_SIZE`                | `65536` (64 KB)                                  |
+| `websocketMaxMessagesPerSecond` | `WS_MAX_MESSAGES_PER_SECOND`         | `20`                                             |
+| `websocketMaxSubscriptions`     | `WS_MAX_SUBSCRIPTIONS`               | `100`                                            |
+
+#### Security Headers
+
+All HTTP responses include these headers. Each is configurable:
+
+| Header                      | Env Var                             | Default                               |
+| --------------------------- | ----------------------------------- | ------------------------------------- |
+| `Content-Security-Policy`   | `WEB_SECURITY_CSP`                  | `default-src 'self'`                  |
+| `X-Content-Type-Options`    | `WEB_SECURITY_CONTENT_TYPE_OPTIONS` | `nosniff`                             |
+| `X-Frame-Options`           | `WEB_SECURITY_FRAME_OPTIONS`        | `DENY`                                |
+| `Strict-Transport-Security` | `WEB_SECURITY_HSTS`                 | `max-age=31536000; includeSubDomains` |
+| `Referrer-Policy`           | `WEB_SECURITY_REFERRER_POLICY`      | `strict-origin-when-cross-origin`     |
 
 ### Tasks
 
@@ -113,6 +136,27 @@ The helper is also type-aware — it parses `"true"`/`"false"` strings into bool
 | `enabled`        | `TASKS_ENABLED`   | `true`  |
 | `timeout`        | `TASK_TIMEOUT`    | `5000`  |
 | `taskProcessors` | `TASK_PROCESSORS` | `1`     |
+
+### Rate Limiting
+
+See the [Security guide](/guide/security) for details on how rate limiting works.
+
+| Key                     | Env Var                               | Default                   |
+| ----------------------- | ------------------------------------- | ------------------------- |
+| `enabled`               | `RATE_LIMIT_ENABLED`                  | `true` (disabled in test) |
+| `windowMs`              | `RATE_LIMIT_WINDOW_MS`                | `60000` (1 min)           |
+| `unauthenticatedLimit`  | `RATE_LIMIT_UNAUTH_LIMIT`             | `20`                      |
+| `authenticatedLimit`    | `RATE_LIMIT_AUTH_LIMIT`               | `200`                     |
+| `keyPrefix`             | `RATE_LIMIT_KEY_PREFIX`               | `"ratelimit"`             |
+| `oauthRegisterLimit`    | `RATE_LIMIT_OAUTH_REGISTER_LIMIT`     | `5`                       |
+| `oauthRegisterWindowMs` | `RATE_LIMIT_OAUTH_REGISTER_WINDOW_MS` | `3600000` (1 hour)        |
+
+### CLI
+
+| Key                    | Env Var                       | Default |
+| ---------------------- | ----------------------------- | ------- |
+| `includeStackInErrors` | `CLI_INCLUDE_STACK_IN_ERRORS` | `true`  |
+| `quiet`                | `CLI_QUIET`                   | `false` |
 
 ### MCP Server
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -48,6 +48,33 @@ APPLICATION_URL=https://api.example.com
 WEB_SERVER_PORT=8080
 ```
 
+## Production Security
+
+Keryx ships with secure defaults, but a few settings need adjustment for production. See the [Security guide](/guide/security) for full details.
+
+```bash
+# Cookies — require HTTPS transport
+SESSION_COOKIE_SECURE=true
+
+# CORS — restrict to your domain (wildcard blocks credentials)
+WEB_SERVER_ALLOWED_ORIGINS=https://yourapp.com
+
+# Rate limiting — enabled by default, tune thresholds as needed
+RATE_LIMIT_UNAUTH_LIMIT=20
+RATE_LIMIT_AUTH_LIMIT=200
+
+# Error stack traces — auto-disabled when NODE_ENV=production
+NODE_ENV=production
+
+# Security headers — defaults are production-ready
+# Customize CSP if your backend serves HTML with external resources:
+# WEB_SECURITY_CSP="default-src 'self'; script-src 'self' https://cdn.example.com"
+
+# WebSocket limits — adjust for your expected traffic
+# WS_MAX_PAYLOAD_SIZE=65536
+# WS_MAX_MESSAGES_PER_SECOND=20
+```
+
 ## Database Migrations
 
 Migrations auto-apply on server start when `DATABASE_AUTO_MIGRATE=true` (the default). If you'd rather run them explicitly before deploying:

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -101,6 +101,14 @@ MCP clients authenticate using OAuth 2.1 with PKCE (Proof Key for Code Exchange)
 | `/oauth/authorize`                        | POST   | Process login/signup form submission   |
 | `/oauth/token`                            | POST   | Exchange authorization code for token  |
 
+### Security
+
+The OAuth implementation includes several hardening measures:
+
+- **Redirect URI validation** — URIs registered via `/oauth/register` must not contain fragments or userinfo, and must use HTTPS for non-localhost addresses. When exchanging authorization codes, the redirect URI must match the registered URI exactly (origin + pathname).
+- **Registration rate limiting** — `POST /oauth/register` has a separate, stricter rate limit (default: 5 requests per hour per IP) to prevent abuse. See `RATE_LIMIT_OAUTH_REGISTER_LIMIT` and `RATE_LIMIT_OAUTH_REGISTER_WINDOW_MS` in [Configuration](/guide/config).
+- **CORS** — OAuth and MCP endpoints respect the `allowedOrigins` configuration. When `allowedOrigins` is `"*"`, credentials headers are not sent, per the browser spec. Set a specific origin in production for credentialed requests to work.
+
 ## Session Management
 
 Each authenticated MCP connection creates its own `McpServer` instance. Sessions are tracked via the `mcp-session-id` header — the MCP SDK generates a UUID per session and includes it in all subsequent requests.

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -104,6 +104,24 @@ export const NormalizeMiddleware: ActionMiddleware = {
 
 That said, you can also handle this in the Zod schema with `.transform()` — so use whichever approach makes more sense for your case.
 
+### Rate Limiting
+
+The built-in `RateLimitMiddleware` uses a Redis-backed sliding window to limit request rates per client. It identifies users by user ID (authenticated) or IP address (unauthenticated):
+
+```ts
+import { RateLimitMiddleware } from "../middleware/rateLimit";
+
+export class ApiEndpoint implements Action {
+  name = "api:endpoint";
+  middleware = [SessionMiddleware, RateLimitMiddleware];
+  // ...
+}
+```
+
+When a client exceeds the limit, the middleware throws a `CONNECTION_RATE_LIMITED` error (HTTP 429). Rate limit info is attached to the connection and included in response headers automatically.
+
+See the [Security guide](/guide/security) for configuration options and custom limit overrides.
+
 ### Response Enrichment
 
 `runAfter` can add data to the response. This runs after the action's `run()` method completes:

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -1,0 +1,174 @@
+---
+description: Built-in security features — rate limiting, security headers, cookie hardening, CORS, WebSocket protections, and OAuth validation.
+---
+
+# Security
+
+Keryx ships with security defaults that are sensible for development and tightenable for production. Most features are configured via environment variables — no code changes needed to go from development to a hardened production deployment.
+
+## Rate Limiting
+
+Rate limiting uses a sliding window algorithm backed by Redis. It's implemented as action middleware, so you can apply it to specific actions or leave it off entirely.
+
+### Setup
+
+Add `RateLimitMiddleware` to any action:
+
+```ts
+import { RateLimitMiddleware } from "../middleware/rateLimit";
+
+export class UserCreate implements Action {
+  name = "user:create";
+  middleware = [RateLimitMiddleware];
+  // ...
+}
+```
+
+The middleware identifies clients by user ID (if authenticated) or IP address (if not), and applies different limits to each:
+
+| Config Key             | Env Var                   | Default       | Description                          |
+| ---------------------- | ------------------------- | ------------- | ------------------------------------ |
+| `enabled`              | `RATE_LIMIT_ENABLED`      | `true`        | Master toggle (disabled in test)     |
+| `windowMs`             | `RATE_LIMIT_WINDOW_MS`    | `60000`       | Sliding window size (ms)             |
+| `unauthenticatedLimit` | `RATE_LIMIT_UNAUTH_LIMIT` | `20`          | Max requests per window (no session) |
+| `authenticatedLimit`   | `RATE_LIMIT_AUTH_LIMIT`   | `200`         | Max requests per window (logged in)  |
+| `keyPrefix`            | `RATE_LIMIT_KEY_PREFIX`   | `"ratelimit"` | Redis key prefix                     |
+
+When a client exceeds the limit, the action returns a `429` with a message indicating how many seconds until the window resets. Rate limit info is also included in response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
+
+### Custom Limits
+
+The `checkRateLimit()` function is exported for use outside of action middleware — for example, the OAuth registration endpoint uses it with a stricter limit:
+
+```ts
+import { checkRateLimit } from "../middleware/rateLimit";
+
+const info = await checkRateLimit(`oauth-register:${ip}`, false, {
+  limit: config.rateLimit.oauthRegisterLimit, // default: 5
+  windowMs: config.rateLimit.oauthRegisterWindowMs, // default: 1 hour
+});
+```
+
+## Security Headers
+
+Every HTTP response includes security headers by default. Each is configurable via environment variable:
+
+| Header                      | Env Var                             | Default                               |
+| --------------------------- | ----------------------------------- | ------------------------------------- |
+| `Content-Security-Policy`   | `WEB_SECURITY_CSP`                  | `default-src 'self'`                  |
+| `X-Content-Type-Options`    | `WEB_SECURITY_CONTENT_TYPE_OPTIONS` | `nosniff`                             |
+| `X-Frame-Options`           | `WEB_SECURITY_FRAME_OPTIONS`        | `DENY`                                |
+| `Strict-Transport-Security` | `WEB_SECURITY_HSTS`                 | `max-age=31536000; includeSubDomains` |
+| `Referrer-Policy`           | `WEB_SECURITY_REFERRER_POLICY`      | `strict-origin-when-cross-origin`     |
+
+These defaults are production-ready. The CSP may need loosening if your backend serves HTML with inline scripts or external resources — adjust via `WEB_SECURITY_CSP`.
+
+## Cookie Security
+
+Session cookies are configured with security flags:
+
+| Config Key       | Env Var                    | Default    | Description                                  |
+| ---------------- | -------------------------- | ---------- | -------------------------------------------- |
+| `cookieHttpOnly` | `SESSION_COOKIE_HTTP_ONLY` | `true`     | Prevents JavaScript access to the cookie     |
+| `cookieSecure`   | `SESSION_COOKIE_SECURE`    | `false`    | Only send cookie over HTTPS                  |
+| `cookieSameSite` | `SESSION_COOKIE_SAME_SITE` | `"Strict"` | CSRF protection (`Strict`, `Lax`, or `None`) |
+
+For production, set `SESSION_COOKIE_SECURE=true` so cookies are only transmitted over HTTPS. The `SameSite=Strict` default prevents CSRF attacks by ensuring cookies aren't sent on cross-origin requests.
+
+## CORS
+
+Cross-origin request handling is configured on the web server:
+
+| Config Key       | Env Var                      | Default                                          |
+| ---------------- | ---------------------------- | ------------------------------------------------ |
+| `allowedOrigins` | `WEB_SERVER_ALLOWED_ORIGINS` | `"*"`                                            |
+| `allowedMethods` | `WEB_SERVER_ALLOWED_METHODS` | `"HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS"` |
+| `allowedHeaders` | `WEB_SERVER_ALLOWED_HEADERS` | `"Content-Type"`                                 |
+
+**Important:** When `allowedOrigins` is `"*"` (the default), the server will not send `Access-Control-Allow-Credentials: true` — this follows the browser spec that forbids wildcard origins with credentials. For production, set `WEB_SERVER_ALLOWED_ORIGINS` to your specific domain(s) so that credentialed requests (cookies, auth headers) work correctly.
+
+## WebSocket Protections
+
+WebSocket connections have several layers of protection:
+
+### Origin Validation
+
+Before upgrading an HTTP connection to WebSocket, the server validates the `Origin` header against `config.server.web.allowedOrigins`. If the origin doesn't match, the upgrade is rejected. This prevents Cross-Site WebSocket Hijacking (CSWSH) attacks.
+
+### Message Limits
+
+| Config Key                      | Env Var                      | Default | Description                        |
+| ------------------------------- | ---------------------------- | ------- | ---------------------------------- |
+| `websocketMaxPayloadSize`       | `WS_MAX_PAYLOAD_SIZE`        | `65536` | Max message size in bytes (64 KB)  |
+| `websocketMaxMessagesPerSecond` | `WS_MAX_MESSAGES_PER_SECOND` | `20`    | Per-connection rate limit          |
+| `websocketMaxSubscriptions`     | `WS_MAX_SUBSCRIPTIONS`       | `100`   | Max channel subscriptions per conn |
+
+Messages exceeding the payload size are rejected. Clients sending more than the per-second limit are disconnected. These protect against resource exhaustion from misbehaving or malicious clients.
+
+### Channel Validation
+
+- **Channel names** must match the pattern `/^[a-zA-Z0-9:._-]{1,200}$/` — alphanumeric characters plus `:`, `.`, `_`, `-`, max 200 characters
+- **Undefined channels** are rejected — if no registered channel matches the requested name, the subscription is denied with a `CHANNEL_NOT_FOUND` error
+
+## OAuth Security
+
+The MCP server's OAuth 2.1 implementation includes several hardening measures:
+
+### Redirect URI Validation
+
+When clients register via `/oauth/register`, redirect URIs are validated:
+
+- Must be a valid URL
+- Must not contain a fragment (`#`)
+- Must not contain userinfo (username/password in the URL)
+- Must use HTTPS for non-localhost URIs
+
+When exchanging authorization codes, the redirect URI must match the registered URI exactly (origin + pathname comparison).
+
+### Registration Rate Limiting
+
+OAuth client registration (`POST /oauth/register`) has a separate, stricter rate limit to prevent abuse:
+
+| Config Key              | Env Var                               | Default   | Description                  |
+| ----------------------- | ------------------------------------- | --------- | ---------------------------- |
+| `oauthRegisterLimit`    | `RATE_LIMIT_OAUTH_REGISTER_LIMIT`     | `5`       | Max registrations per window |
+| `oauthRegisterWindowMs` | `RATE_LIMIT_OAUTH_REGISTER_WINDOW_MS` | `3600000` | Window size (1 hour)         |
+
+## Error Stack Traces
+
+By default, error responses include stack traces in development but omit them in production:
+
+| Config Key | Env Var                              | Default                      |
+| ---------- | ------------------------------------ | ---------------------------- |
+| Web server | `WEB_SERVER_INCLUDE_STACK_IN_ERRORS` | `true` (dev), `false` (prod) |
+| CLI        | `CLI_INCLUDE_STACK_IN_ERRORS`        | `true`                       |
+
+The web server default is based on `NODE_ENV` — when `NODE_ENV=production`, stack traces are automatically hidden from HTTP responses to avoid leaking internal implementation details.
+
+## Static File Path Traversal
+
+Static file serving validates requested paths to prevent directory traversal attacks. Requests containing `..` segments that would escape the configured static files directory are rejected with a `403`.
+
+## Production Checklist
+
+When deploying to production, review these environment variables:
+
+```bash
+# Cookie security — require HTTPS
+SESSION_COOKIE_SECURE=true
+
+# CORS — restrict to your domain
+WEB_SERVER_ALLOWED_ORIGINS=https://yourapp.com
+
+# Rate limiting — tune for your traffic
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_UNAUTH_LIMIT=20
+RATE_LIMIT_AUTH_LIMIT=200
+
+# Error responses — hide internals
+NODE_ENV=production
+# (stack traces auto-disabled when NODE_ENV=production)
+
+# Security headers — defaults are good, customize CSP if needed
+WEB_SECURITY_CSP="default-src 'self'; script-src 'self'"
+```


### PR DESCRIPTION
## Summary

- **New `docs/guide/security.md`** — Comprehensive security guide covering rate limiting, security headers, cookie hardening, CORS, WebSocket protections, OAuth security, error stack traces, and a production checklist
- **Updated `docs/guide/config.md`** — Added rate limit, CLI, session cookie security, WebSocket limits, security headers, and CORS config tables. Fixed stale session TTL units (was ms, now correctly seconds). Updated config directory tree.
- **Updated `docs/guide/channels.md`** — Added WebSocket Security section (channel name validation, undefined channel denial, origin validation, connection limits)
- **Updated `docs/guide/mcp.md`** — Added OAuth Security subsection (redirect URI validation, registration rate limiting, CORS)
- **Updated `docs/guide/middleware.md`** — Added RateLimitMiddleware pattern
- **Updated `docs/guide/testing.md`** — Updated test structure for dynamic ports, added Test Helpers section (`serverUrl()`, `HOOK_TIMEOUT`, `waitFor()`), fixed stale `bun-test` → `keryx-test` database name
- **Updated `docs/guide/deployment.md`** — Added Production Security section with env var checklist
- **Updated sidebar** — Added Security page under Usage

## Test plan

- [x] `bun lint` passes (prettier check on docs)
- [x] `bun docs:build` succeeds with no errors
- [ ] Preview docs locally with `bun docs:dev` and verify all new/updated pages render correctly
- [ ] Verify all cross-page links work (security ↔ config ↔ channels ↔ mcp ↔ middleware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)