### PR TITLE
Update docs color scheme to match SVG imagery

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,30 +1,30 @@
 :root {
-  --vp-c-brand-1: #2f5266;
-  --vp-c-brand-2: #3a6a84;
-  --vp-c-brand-3: #e14e3a;
-  --vp-c-brand-soft: rgba(47, 82, 102, 0.14);
+  --vp-c-brand-1: #b8701e;
+  --vp-c-brand-2: #cf8128;
+  --vp-c-brand-3: #bb5533;
+  --vp-c-brand-soft: rgba(207, 129, 40, 0.14);
 
-  --vp-button-brand-bg: #2f5266;
-  --vp-button-brand-hover-bg: #3a6a84;
-  --vp-button-brand-active-bg: #254352;
+  --vp-button-brand-bg: #b8701e;
+  --vp-button-brand-hover-bg: #cf8128;
+  --vp-button-brand-active-bg: #9a5e18;
 
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(135deg, #2f5266, #e14e3a);
+  --vp-home-hero-name-background: linear-gradient(135deg, #cf8128, #bb5533);
   --vp-home-hero-image-background-image: linear-gradient(
     135deg,
-    rgba(47, 82, 102, 0.3),
-    rgba(225, 78, 58, 0.3)
+    rgba(207, 129, 40, 0.3),
+    rgba(187, 85, 51, 0.3)
   );
   --vp-home-hero-image-filter: blur(40px);
 }
 
 .dark {
-  --vp-c-brand-1: #5a9abb;
-  --vp-c-brand-2: #7ab4d0;
-  --vp-c-brand-3: #e8715f;
-  --vp-c-brand-soft: rgba(90, 154, 187, 0.14);
+  --vp-c-brand-1: #e0a04a;
+  --vp-c-brand-2: #eab56e;
+  --vp-c-brand-3: #d4795e;
+  --vp-c-brand-soft: rgba(224, 160, 74, 0.14);
 
-  --vp-button-brand-bg: #3a6a84;
-  --vp-button-brand-hover-bg: #5a9abb;
-  --vp-button-brand-active-bg: #2f5266;
+  --vp-button-brand-bg: #b8701e;
+  --vp-button-brand-hover-bg: #cf8128;
+  --vp-button-brand-active-bg: #9a5e18;
 }


### PR DESCRIPTION
## Summary
- Replace the steel blue / red VitePress theme with a warm gold / amber / rust palette
- Colors derived from the lion and horn SVG assets used throughout the docs site
- Updates both light and dark mode variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)