### PR TITLE
Refactor Conductor setup to read from .env.example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Similarly for frontend:
 cp frontend/.env.example frontend/.env
 ```
 
-**Important**: When adding, removing, or changing environment variables, also update the `.env` template in `.conductor/setup.ts`. That script generates `.env` files for parallel Conductor workspaces and must stay in sync with `.env.example`.
+**Note**: `.conductor/setup.ts` reads from `.env.example` and only overrides workspace-specific variables (ports, database names, Redis DBs). New environment variables added to `.env.example` will automatically flow through to Conductor workspaces.
 
 ## Common Commands
 


### PR DESCRIPTION
## Summary

The setup script now reads `.env.example` files directly and only overrides workspace-specific variables (ports, database names, Redis DBs), eliminating drift between hardcoded env templates and the source examples. New environment variables added to `.env.example` automatically flow through to Conductor workspaces.

## Changes

- Extract env generation logic into `applyEnvOverrides()` function that parses `.env.example` and applies targeted overrides
- Remove hardcoded env templates; read from source files instead
- Update CLAUDE.md to reflect the new approach

## Test plan

- Run `bun .conductor/setup.ts` in a workspace and verify generated `.env` files are correct
- Confirm that adding a new variable to `.env.example` appears in generated `.env` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)