### PR TITLE
Fix Superset scripts: add Homebrew Postgres bin to PATH

### DIFF
--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -14,6 +14,14 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Ensure Homebrew Postgres binaries (psql, createdb, pg_isready) are on PATH
+if command -v brew &>/dev/null; then
+  PG_PREFIX="$(brew --prefix postgresql@17 2>/dev/null || true)"
+  if [ -n "$PG_PREFIX" ] && [ -d "$PG_PREFIX/bin" ]; then
+    export PATH="$PG_PREFIX/bin:$PATH"
+  fi
+fi
+
 if [ -z "${SUPERSET_WORKSPACE_NAME:-}" ]; then
   echo "SUPERSET_WORKSPACE_NAME is not set. Using defaults."
   BACKEND_PORT=8080

--- a/.superset/teardown.sh
+++ b/.superset/teardown.sh
@@ -10,6 +10,14 @@
 
 set -euo pipefail
 
+# Ensure Homebrew Postgres binaries (dropdb) are on PATH
+if command -v brew &>/dev/null; then
+  PG_PREFIX="$(brew --prefix postgresql@17 2>/dev/null || true)"
+  if [ -n "$PG_PREFIX" ] && [ -d "$PG_PREFIX/bin" ]; then
+    export PATH="$PG_PREFIX/bin:$PATH"
+  fi
+fi
+
 if [ -z "${SUPERSET_WORKSPACE_NAME:-}" ]; then
   echo "SUPERSET_WORKSPACE_NAME is not set. Nothing to tear down."
   exit 0


### PR DESCRIPTION
## Summary
- `pg_isready`, `psql`, `createdb`, and `dropdb` aren't on `$PATH` in non-interactive shells on macOS with Homebrew Postgres
- Both `setup.sh` and `teardown.sh` now resolve the Postgres bin directory via `brew --prefix postgresql@17` early and prepend it to PATH
- Fixes false "Postgres is not running" detection and `createdb`/`dropdb` failures in Superset worktree scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)