### PR TITLE
Add user config file support and include config in scaffold

### DIFF
--- a/packages/keryx/__tests__/scaffold-cli.test.ts
+++ b/packages/keryx/__tests__/scaffold-cli.test.ts
@@ -48,6 +48,7 @@ describe("keryx new (CLI integration)", () => {
     ".env.example",
     ".gitignore",
     "migrations.ts",
+    "config/index.ts",
     "actions/hello.ts",
   ];
 

--- a/packages/keryx/__tests__/scaffold.test.ts
+++ b/packages/keryx/__tests__/scaffold.test.ts
@@ -31,6 +31,18 @@ describe("scaffoldProject", () => {
     expect(files).toContain("tsconfig.json");
     expect(files).toContain(".env.example");
     expect(files).toContain(".gitignore");
+    expect(files).toContain("config/index.ts");
+    expect(files).toContain("config/channels.ts");
+    expect(files).toContain("config/database.ts");
+    expect(files).toContain("config/logger.ts");
+    expect(files).toContain("config/process.ts");
+    expect(files).toContain("config/rateLimit.ts");
+    expect(files).toContain("config/redis.ts");
+    expect(files).toContain("config/session.ts");
+    expect(files).toContain("config/tasks.ts");
+    expect(files).toContain("config/server/cli.ts");
+    expect(files).toContain("config/server/mcp.ts");
+    expect(files).toContain("config/server/web.ts");
     expect(files).toContain("initializers/.gitkeep");
     expect(files).toContain("middleware/.gitkeep");
     expect(files).toContain("channels/.gitkeep");
@@ -117,6 +129,34 @@ describe("scaffoldProject", () => {
     );
     expect(content).toContain("PROCESS_NAME=cool-api");
     expect(content).toContain("cool-api");
+  });
+
+  test("config files use keryx package imports", async () => {
+    await scaffoldProject("check-config", targetDir("check-config"), {
+      includeDb: false,
+      includeExample: false,
+    });
+
+    const process = fs.readFileSync(
+      path.join(targetDir("check-config"), "config/process.ts"),
+      "utf-8",
+    );
+    expect(process).toContain('from "keryx"');
+    expect(process).not.toContain("../util/config");
+
+    const web = fs.readFileSync(
+      path.join(targetDir("check-config"), "config/server/web.ts"),
+      "utf-8",
+    );
+    expect(web).toContain('from "keryx"');
+    expect(web).not.toContain("../../util/config");
+
+    const index = fs.readFileSync(
+      path.join(targetDir("check-config"), "config/index.ts"),
+      "utf-8",
+    );
+    expect(index).toContain("export default");
+    expect(index).not.toContain("export const config");
   });
 
   test("throws if directory already exists", async () => {

--- a/packages/keryx/config/index.ts
+++ b/packages/keryx/config/index.ts
@@ -21,3 +21,5 @@ export const config = {
   server: { cli: configServerCli, web: configServerWeb, mcp: configServerMcp },
   tasks: configTasks,
 };
+
+export type KeryxConfig = typeof config;

--- a/packages/keryx/index.ts
+++ b/packages/keryx/index.ts
@@ -19,7 +19,8 @@ import "./initializers/swagger";
 export * from "./api";
 export type { ActionMiddleware } from "./classes/Action";
 export { ErrorStatusCodes, ErrorType, TypedError } from "./classes/TypedError";
-export { loadFromEnvIfSet } from "./util/config";
+export type { KeryxConfig } from "./config";
+export { deepMerge, loadFromEnvIfSet } from "./util/config";
 export { globLoader } from "./util/glob";
 export {
   isSecret,

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",
@@ -61,6 +61,7 @@
     "start": "bun keryx.ts start",
     "dev": "bun --watch keryx.ts start",
     "migrations": "bun run migrations.ts",
+    "test": "tsc && bun test",
     "compile": "bun build keryx.ts --compile --outfile keryx",
     "lint": "tsc && prettier --check .",
     "format": "tsc && prettier --write ."

--- a/packages/keryx/util/config.ts
+++ b/packages/keryx/util/config.ts
@@ -1,4 +1,33 @@
 /**
+Deep-merges source into target, mutating target in place.
+Only plain objects are recursively merged; arrays and primitives are overwritten.
+*/
+export function deepMerge<T extends Record<string, any>>(
+  target: T,
+  source: Record<string, any>,
+): T {
+  for (const key of Object.keys(source)) {
+    const targetVal = target[key];
+    const sourceVal = source[key];
+
+    if (
+      targetVal &&
+      sourceVal &&
+      typeof targetVal === "object" &&
+      typeof sourceVal === "object" &&
+      !Array.isArray(targetVal) &&
+      !Array.isArray(sourceVal)
+    ) {
+      deepMerge(targetVal, sourceVal);
+    } else {
+      (target as any)[key] = sourceVal;
+    }
+  }
+
+  return target;
+}
+
+/**
 Loads a value from the environment, if it's set, otherwise returns the default value.
 */
 export async function loadFromEnvIfSet<T>(envString: string, defaultValue: T) {


### PR DESCRIPTION
## Summary
- Framework now auto-discovers and deep-merges config files from `rootDir/config/` during `api.initialize()`, enabling config file overrides (not just env vars)
- Scaffold (`keryx new`) copies all framework config files into new projects with imports rewritten to `"keryx"`
- Adds `deepMerge` utility, exports `KeryxConfig` type, and adds `tsc` to package test script
- Bumps package version to 0.2.0

## Test plan
- [x] `deepMerge` unit tests (nested merge, primitives, arrays, new keys, deeply nested)
- [x] Scaffold tests verify all 11 config files are generated
- [x] Scaffold tests verify import rewriting (`"keryx"` instead of relative paths)
- [x] Scaffold CLI integration test includes `config/index.ts`
- [ ] Manual: `bunx keryx new test-app` produces working config directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)