### PR TITLE
Add `keryx upgrade` CLI command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,7 @@ import { SessionMiddleware } from "../middleware/session";
 ## Coding Conventions
 
 - **No `as any`** — Never use `as any` type assertions. Use `@ts-expect-error` with an explanatory comment when the type system can't express something, or add a proper type/interface.
+- **Always `bunx`, never `npx`** — This is a Bun project. Use `bunx` for all package runner commands.
 
 ## Testing Patterns
 

--- a/packages/keryx/__tests__/scaffold-cli.test.ts
+++ b/packages/keryx/__tests__/scaffold-cli.test.ts
@@ -100,32 +100,27 @@ describe("keryx new (CLI integration)", () => {
       path.join(os.tmpdir(), "keryx-cli-scaffold-y-"),
     );
     try {
-      const proc = Bun.spawn(
-        ["bun", keryxTs, "new", "y-flag-app", "-y"],
-        {
-          cwd: yTmpDir,
-          stdout: "pipe",
-          stderr: "pipe",
-        },
-      );
+      const proc = Bun.spawn(["bun", keryxTs, "new", "y-flag-app", "-y"], {
+        cwd: yTmpDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
       const exitCode = await proc.exited;
       if (exitCode !== 0) {
         const stderr = await new Response(proc.stderr).text();
-        throw new Error(`keryx new -y failed with exit code ${exitCode}: ${stderr}`);
+        throw new Error(
+          `keryx new -y failed with exit code ${exitCode}: ${stderr}`,
+        );
       }
 
       const yProjectDir = path.join(yTmpDir, "y-flag-app");
       expect(fs.existsSync(yProjectDir)).toBe(true);
-      expect(
-        fs.existsSync(path.join(yProjectDir, "package.json")),
-      ).toBe(true);
-      expect(
-        fs.existsSync(path.join(yProjectDir, "migrations.ts")),
-      ).toBe(true);
-      expect(
-        fs.existsSync(path.join(yProjectDir, "actions/hello.ts")),
-      ).toBe(true);
+      expect(fs.existsSync(path.join(yProjectDir, "package.json"))).toBe(true);
+      expect(fs.existsSync(path.join(yProjectDir, "migrations.ts"))).toBe(true);
+      expect(fs.existsSync(path.join(yProjectDir, "actions/hello.ts"))).toBe(
+        true,
+      );
     } finally {
       fs.rmSync(yTmpDir, { recursive: true, force: true });
     }
@@ -148,17 +143,19 @@ describe("keryx new (CLI integration)", () => {
       const exitCode = await proc.exited;
       if (exitCode !== 0) {
         const stderr = await new Response(proc.stderr).text();
-        throw new Error(`keryx new -y failed with exit code ${exitCode}: ${stderr}`);
+        throw new Error(
+          `keryx new -y failed with exit code ${exitCode}: ${stderr}`,
+        );
       }
 
       const yProjectDir = path.join(yTmpDir, "y-opts-app");
       expect(fs.existsSync(yProjectDir)).toBe(true);
-      expect(
-        fs.existsSync(path.join(yProjectDir, "migrations.ts")),
-      ).toBe(false);
-      expect(
-        fs.existsSync(path.join(yProjectDir, "actions/hello.ts")),
-      ).toBe(false);
+      expect(fs.existsSync(path.join(yProjectDir, "migrations.ts"))).toBe(
+        false,
+      );
+      expect(fs.existsSync(path.join(yProjectDir, "actions/hello.ts"))).toBe(
+        false,
+      );
     } finally {
       fs.rmSync(yTmpDir, { recursive: true, force: true });
     }

--- a/packages/keryx/__tests__/upgrade-cli.test.ts
+++ b/packages/keryx/__tests__/upgrade-cli.test.ts
@@ -1,0 +1,197 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const keryxTs = path.join(import.meta.dir, "..", "keryx.ts");
+let tmpDir: string;
+let projectDir: string;
+
+async function runKeryx(
+  args: string[],
+  cwd: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", keryxTs, ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "keryx-cli-upgrade-"));
+
+  const { exitCode, stderr } = await runKeryx(
+    ["new", "upgrade-test-app", "-y"],
+    tmpDir,
+  );
+  if (exitCode !== 0) {
+    throw new Error(`keryx new failed: ${stderr}`);
+  }
+
+  projectDir = path.join(tmpDir, "upgrade-test-app");
+});
+
+afterAll(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+describe("keryx upgrade (CLI integration)", () => {
+  test("reports all files up to date on fresh scaffold", async () => {
+    const { exitCode, stdout } = await runKeryx(
+      ["upgrade", "--force"],
+      projectDir,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("already up to date");
+    expect(stdout).not.toContain("⚡ updated");
+    expect(stdout).not.toContain("+ created");
+  });
+
+  test("detects and updates a modified config file with --force", async () => {
+    const configPath = path.join(projectDir, "config/process.ts");
+    const original = fs.readFileSync(configPath, "utf-8");
+    fs.writeFileSync(configPath, "// user modification\n");
+
+    const { exitCode, stdout } = await runKeryx(
+      ["upgrade", "--force"],
+      projectDir,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("⚡ updated");
+    expect(stdout).toContain("config/process.ts");
+
+    // File should be restored
+    const restored = fs.readFileSync(configPath, "utf-8");
+    expect(restored).toBe(original);
+  });
+
+  test("detects and updates a modified action with -y", async () => {
+    const statusPath = path.join(projectDir, "actions/status.ts");
+    fs.writeFileSync(statusPath, "// modified\n");
+
+    const { exitCode, stdout } = await runKeryx(["upgrade", "-y"], projectDir);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("⚡ updated");
+    expect(stdout).toContain("actions/status.ts");
+
+    const restored = fs.readFileSync(statusPath, "utf-8");
+    expect(restored).toContain('from "keryx"');
+  });
+
+  test("--dry-run shows changes without writing", async () => {
+    const configPath = path.join(projectDir, "config/redis.ts");
+    const original = fs.readFileSync(configPath, "utf-8");
+    const modified = "// dry run test\n";
+    fs.writeFileSync(configPath, modified);
+
+    const { exitCode, stdout } = await runKeryx(
+      ["upgrade", "--dry-run"],
+      projectDir,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("would update");
+    expect(stdout).toContain("config/redis.ts");
+
+    // File should NOT have changed
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(modified);
+
+    // Restore for subsequent tests
+    fs.writeFileSync(configPath, original);
+  });
+
+  test("recreates deleted framework files", async () => {
+    const swaggerPath = path.join(projectDir, "actions/swagger.ts");
+    fs.unlinkSync(swaggerPath);
+    expect(fs.existsSync(swaggerPath)).toBe(false);
+
+    const { exitCode, stdout } = await runKeryx(
+      ["upgrade", "--force"],
+      projectDir,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("+ created");
+    expect(stdout).toContain("actions/swagger.ts");
+    expect(fs.existsSync(swaggerPath)).toBe(true);
+  });
+
+  test("does not touch user-owned files", async () => {
+    const helloPath = path.join(projectDir, "actions/hello.ts");
+    const indexPath = path.join(projectDir, "index.ts");
+    const keryxPath = path.join(projectDir, "keryx.ts");
+    const envPath = path.join(projectDir, ".env.example");
+
+    const helloBefore = fs.readFileSync(helloPath, "utf-8");
+    const indexBefore = fs.readFileSync(indexPath, "utf-8");
+    const keryxBefore = fs.readFileSync(keryxPath, "utf-8");
+    const envBefore = fs.readFileSync(envPath, "utf-8");
+
+    await runKeryx(["upgrade", "--force"], projectDir);
+
+    expect(fs.readFileSync(helloPath, "utf-8")).toBe(helloBefore);
+    expect(fs.readFileSync(indexPath, "utf-8")).toBe(indexBefore);
+    expect(fs.readFileSync(keryxPath, "utf-8")).toBe(keryxBefore);
+    expect(fs.readFileSync(envPath, "utf-8")).toBe(envBefore);
+  });
+
+  test("fails in a directory without package.json", async () => {
+    const emptyDir = path.join(tmpDir, "empty");
+    fs.mkdirSync(emptyDir);
+
+    const { exitCode, stderr } = await runKeryx(
+      ["upgrade", "--force"],
+      emptyDir,
+    );
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("No package.json found");
+  });
+
+  test("fails in a directory without keryx dependency", async () => {
+    const noKeryxDir = path.join(tmpDir, "no-keryx");
+    fs.mkdirSync(noKeryxDir);
+    fs.writeFileSync(
+      path.join(noKeryxDir, "package.json"),
+      JSON.stringify({ name: "not-keryx", dependencies: {} }),
+    );
+
+    const { exitCode, stderr } = await runKeryx(
+      ["upgrade", "--force"],
+      noKeryxDir,
+    );
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("does not have");
+  });
+
+  test("prints summary with correct counts", async () => {
+    // Modify two files, delete one
+    fs.writeFileSync(
+      path.join(projectDir, "config/session.ts"),
+      "// changed\n",
+    );
+    fs.writeFileSync(path.join(projectDir, "config/tasks.ts"), "// changed\n");
+
+    const { exitCode, stdout } = await runKeryx(
+      ["upgrade", "--force"],
+      projectDir,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Updated 2 file(s)");
+    expect(stdout).toContain("13 already up to date");
+  });
+});

--- a/packages/keryx/__tests__/upgrade.test.ts
+++ b/packages/keryx/__tests__/upgrade.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { scaffoldProject } from "../util/scaffold";
+import { upgradeProject } from "../util/upgrade";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "keryx-upgrade-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function projectDir() {
+  return path.join(tmpDir, "test-app");
+}
+
+async function scaffold() {
+  await scaffoldProject("test-app", projectDir(), {
+    includeDb: true,
+    includeExample: true,
+  });
+}
+
+describe("upgradeProject", () => {
+  test("reports all files up to date after fresh scaffold", async () => {
+    await scaffold();
+
+    // Capture console output
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+
+    try {
+      await upgradeProject(projectDir(), { dryRun: false, force: true });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join("\n");
+    expect(output).toContain("up to date");
+    expect(output).not.toContain("⚡ updated");
+    expect(output).not.toContain("+ created");
+    expect(output).toContain("15 already up to date");
+  });
+
+  test("detects and updates modified config file with --force", async () => {
+    await scaffold();
+
+    // Modify a config file
+    const configPath = path.join(projectDir(), "config/process.ts");
+    fs.writeFileSync(configPath, "// modified by user\n");
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+
+    try {
+      await upgradeProject(projectDir(), { dryRun: false, force: true });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join("\n");
+    expect(output).toContain("updated");
+    expect(output).toContain("config/process.ts");
+
+    // Verify the file was restored
+    const restored = fs.readFileSync(configPath, "utf-8");
+    expect(restored).not.toBe("// modified by user\n");
+    expect(restored).toContain('from "keryx"');
+  });
+
+  test("--dry-run does not write files", async () => {
+    await scaffold();
+
+    // Modify a config file
+    const configPath = path.join(projectDir(), "config/process.ts");
+    const modified = "// modified by user\n";
+    fs.writeFileSync(configPath, modified);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+
+    try {
+      await upgradeProject(projectDir(), { dryRun: true, force: false });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join("\n");
+    expect(output).toContain("would update");
+
+    // File should NOT have changed
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(modified);
+  });
+
+  test("creates missing framework files", async () => {
+    await scaffold();
+
+    // Delete a framework-owned file
+    const statusPath = path.join(projectDir(), "actions/status.ts");
+    fs.unlinkSync(statusPath);
+    expect(fs.existsSync(statusPath)).toBe(false);
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+
+    try {
+      await upgradeProject(projectDir(), { dryRun: false, force: true });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join("\n");
+    expect(output).toContain("created");
+    expect(output).toContain("actions/status.ts");
+    expect(fs.existsSync(statusPath)).toBe(true);
+  });
+
+  test("throws error in non-keryx directory", async () => {
+    const emptyDir = path.join(tmpDir, "empty");
+    fs.mkdirSync(emptyDir);
+
+    expect(
+      upgradeProject(emptyDir, { dryRun: false, force: false }),
+    ).rejects.toThrow("No package.json found");
+  });
+
+  test("throws error when keryx is not a dependency", async () => {
+    const dir = path.join(tmpDir, "no-keryx");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name: "test", dependencies: {} }),
+    );
+
+    expect(
+      upgradeProject(dir, { dryRun: false, force: false }),
+    ).rejects.toThrow('does not have "keryx" as a dependency');
+  });
+});

--- a/packages/keryx/keryx.ts
+++ b/packages/keryx/keryx.ts
@@ -11,6 +11,7 @@ import {
   scaffoldProject,
   type ScaffoldOptions,
 } from "./util/scaffold";
+import { upgradeProject } from "./util/upgrade";
 
 const program = new Command();
 program.name(pkg.name).description(pkg.description).version(pkg.version);
@@ -55,6 +56,25 @@ Done! To get started:
   bun dev
 `);
     process.exit(0);
+  });
+
+program
+  .command("upgrade")
+  .summary("Update framework-owned files to match the installed keryx version")
+  .option("--dry-run", "Show what would change without writing files")
+  .option("--force", "Overwrite all framework files without confirmation")
+  .option("-y, --yes", "Overwrite all framework files without confirmation")
+  .action(async (opts) => {
+    try {
+      await upgradeProject(process.cwd(), {
+        dryRun: opts.dryRun || false,
+        force: opts.force || opts.yes || false,
+      });
+      process.exit(0);
+    } catch (e) {
+      console.error((e as Error).message);
+      process.exit(1);
+    }
   });
 
 program

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/upgrade.ts
+++ b/packages/keryx/util/upgrade.ts
@@ -1,0 +1,163 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as readline from "readline";
+import pkg from "../package.json";
+import {
+  generateBuiltinActionContents,
+  generateConfigFileContents,
+  generateTsconfigContents,
+} from "./scaffold";
+
+export interface UpgradeOptions {
+  dryRun: boolean;
+  force: boolean;
+}
+
+interface UpgradeSummary {
+  updated: number;
+  created: number;
+  skipped: number;
+  upToDate: number;
+}
+
+async function promptOverwrite(filePath: string): Promise<"y" | "n" | "d"> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(`  Overwrite ${filePath}? (y/n/d for diff) `, (answer) => {
+      rl.close();
+      const a = answer.trim().toLowerCase();
+      if (a === "d") resolve("d");
+      else if (a === "y") resolve("y");
+      else resolve("n");
+    });
+  });
+}
+
+async function showDiff(
+  existingPath: string,
+  newContent: string,
+): Promise<void> {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `keryx-upgrade-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await Bun.write(tmpFile, newContent);
+  try {
+    const proc = Bun.spawn(["diff", "-u", existingPath, tmpFile], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+    if (output) {
+      console.log(output);
+    }
+  } finally {
+    fs.unlinkSync(tmpFile);
+  }
+}
+
+export async function upgradeProject(
+  targetDir: string,
+  options: UpgradeOptions,
+): Promise<void> {
+  // Validate this is a keryx project
+  const pkgPath = path.join(targetDir, "package.json");
+  if (!fs.existsSync(pkgPath)) {
+    throw new Error(
+      "No package.json found. Run this command from a Keryx project directory.",
+    );
+  }
+
+  const projectPkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+  const deps = {
+    ...projectPkg.dependencies,
+    ...projectPkg.devDependencies,
+  };
+  if (!deps.keryx) {
+    throw new Error(
+      'This project does not have "keryx" as a dependency. Run this command from a Keryx project directory.',
+    );
+  }
+
+  console.log(`Upgrading project files to match keryx v${pkg.version}\n`);
+
+  // Generate all framework-owned file contents
+  const files = new Map<string, string>();
+
+  const configFiles = await generateConfigFileContents();
+  for (const [p, content] of configFiles) files.set(p, content);
+
+  const actionFiles = await generateBuiltinActionContents();
+  for (const [p, content] of actionFiles) files.set(p, content);
+
+  files.set("tsconfig.json", generateTsconfigContents());
+
+  const summary: UpgradeSummary = {
+    updated: 0,
+    created: 0,
+    skipped: 0,
+    upToDate: 0,
+  };
+
+  for (const [relativePath, newContent] of files) {
+    const fullPath = path.join(targetDir, relativePath);
+
+    if (!fs.existsSync(fullPath)) {
+      // New file — create it
+      if (!options.dryRun) {
+        fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+        await Bun.write(fullPath, newContent);
+      }
+      console.log(`  + created  ${relativePath}`);
+      summary.created++;
+      continue;
+    }
+
+    const existingContent = await Bun.file(fullPath).text();
+    if (existingContent === newContent) {
+      console.log(`  ✓ up to date  ${relativePath}`);
+      summary.upToDate++;
+      continue;
+    }
+
+    // File differs
+    if (options.dryRun) {
+      console.log(`  ⚡ would update  ${relativePath}`);
+      summary.updated++;
+      continue;
+    }
+
+    if (options.force) {
+      await Bun.write(fullPath, newContent);
+      console.log(`  ⚡ updated  ${relativePath}`);
+      summary.updated++;
+      continue;
+    }
+
+    // Interactive prompt
+    let answer = await promptOverwrite(relativePath);
+    while (answer === "d") {
+      await showDiff(fullPath, newContent);
+      answer = await promptOverwrite(relativePath);
+    }
+
+    if (answer === "y") {
+      await Bun.write(fullPath, newContent);
+      console.log(`  ⚡ updated  ${relativePath}`);
+      summary.updated++;
+    } else {
+      console.log(`  ⊘ skipped  ${relativePath}`);
+      summary.skipped++;
+    }
+  }
+
+  console.log(
+    `\nUpdated ${summary.updated} file(s), created ${summary.created} file(s), ${summary.upToDate} already up to date` +
+      (summary.skipped > 0 ? `, ${summary.skipped} skipped` : ""),
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `keryx upgrade` command that updates framework-owned files (config, built-in actions, tsconfig) to match the installed keryx version
- Supports `--dry-run` (preview changes), `--force` / `-y` (skip prompts), and interactive mode with diff viewing
- Extracts `generateConfigFileContents()`, `generateBuiltinActionContents()`, and `generateTsconfigContents()` helpers from scaffold for reuse
- Bumps version to 0.3.1
- Adds `bunx` convention to CLAUDE.md

## Test plan

- [x] Existing scaffold tests pass (unit + CLI)
- [x] New upgrade unit tests: idempotent, force update, dry-run, recreate missing, error cases
- [x] New upgrade CLI integration tests: end-to-end via `bun keryx.ts upgrade`
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)