### PR TITLE
Fix zod v3 compat type error in mcp.ts (#155)

### DIFF
--- a/packages/keryx/initializers/mcp.ts
+++ b/packages/keryx/initializers/mcp.ts
@@ -2,7 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import colors from "colors";
 import { randomUUID } from "crypto";
-import { z } from "zod";
 import * as z4mini from "zod/v4-mini";
 import { api, logger } from "../api";
 import { Connection } from "../classes/Connection";
@@ -462,16 +461,16 @@ function sanitizeSchemaForMcp(schema: any): any {
     schema.shape as Record<string, any>,
   )) {
     try {
-      z4mini.toJSONSchema(z.object({ [key]: fieldSchema }), {
+      z4mini.toJSONSchema(z4mini.object({ [key]: fieldSchema }), {
         target: "draft-7",
         io: "input",
       });
       newShape[key] = fieldSchema;
     } catch {
       needsSanitization = true;
-      newShape[key] = z.string().describe(`${key}`);
+      newShape[key] = z4mini.string();
     }
   }
 
-  return needsSanitization ? z.object(newShape) : schema;
+  return needsSanitization ? z4mini.object(newShape) : schema;
 }


### PR DESCRIPTION
## Summary

- Use `z4mini.object()`/`z4mini.string()` instead of bare `z.object()`/`z.string()` in `sanitizeSchemaForMcp`, so schema construction and `toJSONSchema()` both use v4-native types
- Removes unused `import { z } from "zod"` from `mcp.ts`
- Fixes `TS2769` when consumers depend on zod v3 compat (`"zod": "^3.24.0"`)

Closes #155

## Test plan

- [x] All 34 MCP tests pass
- [x] Full CI passes (lint + all tests + docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)