### PR TITLE
Add graceful WebSocket drain on shutdown

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -125,6 +125,7 @@ The helper is also type-aware — it parses `"true"`/`"false"` strings into bool
 | `websocketMaxPayloadSize`       | `WS_MAX_PAYLOAD_SIZE`                | `65536` (64 KB)                                  |
 | `websocketMaxMessagesPerSecond` | `WS_MAX_MESSAGES_PER_SECOND`         | `20`                                             |
 | `websocketMaxSubscriptions`     | `WS_MAX_SUBSCRIPTIONS`               | `100`                                            |
+| `websocketDrainTimeout`         | `WS_DRAIN_TIMEOUT`                   | `5000` (5 s)                                     |
 
 #### Correlation IDs
 

--- a/packages/keryx/__tests__/servers/websocket-drain.test.ts
+++ b/packages/keryx/__tests__/servers/websocket-drain.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { api } from "../../api";
+import { config } from "../../config";
+import type { WebServer } from "../../servers/web";
+import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { buildWebSocket } from "./websocket-helpers";
+
+beforeAll(async () => {
+  await api.start();
+  await api.db.clearDatabase();
+}, HOOK_TIMEOUT);
+
+afterAll(async () => {
+  // Server may already be stopped by the drain test
+  try {
+    await api.stop();
+  } catch (_e) {
+    // ignore
+  }
+}, HOOK_TIMEOUT);
+
+test("sends close frame with reason to WebSocket clients on shutdown", async () => {
+  const { socket } = await buildWebSocket();
+
+  // Verify the socket is open
+  expect(socket.readyState).toBe(WebSocket.OPEN);
+
+  // Track close event
+  const closeEvent = new Promise<CloseEvent>((resolve) => {
+    socket.addEventListener("close", resolve);
+  });
+
+  // Use a short drain timeout for tests
+  const originalTimeout = config.server.web.websocketDrainTimeout;
+  (config.server.web as any).websocketDrainTimeout = 500;
+
+  try {
+    // Stop just the web server (not the full api, so other tests can still use shared resources)
+    const web = api.servers.servers.find((s) => s.name === "web") as WebServer;
+    await web.stop();
+
+    const event = await closeEvent;
+    // Bun's WebSocket client normalizes close codes to 1000, but the reason
+    // string is propagated correctly. Browser clients will receive the actual
+    // 1001 code. The server sends close(1001, "Server shutting down").
+    expect(event.reason).toBe("Server shutting down");
+  } finally {
+    (config.server.web as any).websocketDrainTimeout = originalTimeout;
+  }
+});
+
+test("cleans up all WebSocket connections on shutdown", async () => {
+  // Restart the web server for this test
+  const web = api.servers.servers.find((s) => s.name === "web") as WebServer;
+  // @ts-expect-error reset private field for testing
+  web.shuttingDown = false;
+  await web.start();
+
+  const { socket: _socket1 } = await buildWebSocket();
+  const { socket: _socket2 } = await buildWebSocket();
+
+  // Verify both are tracked
+  const wsBefore = [...api.connections.connections.values()].filter(
+    (c) => c.type === "websocket",
+  );
+  expect(wsBefore.length).toBe(2);
+
+  const originalTimeout = config.server.web.websocketDrainTimeout;
+  (config.server.web as any).websocketDrainTimeout = 500;
+
+  try {
+    await web.stop();
+
+    // All WebSocket connections should be cleaned up
+    const wsAfter = [...api.connections.connections.values()].filter(
+      (c) => c.type === "websocket",
+    );
+    expect(wsAfter.length).toBe(0);
+  } finally {
+    (config.server.web as any).websocketDrainTimeout = originalTimeout;
+  }
+});
+
+test("rejects new WebSocket upgrades during shutdown", async () => {
+  const web = api.servers.servers.find((s) => s.name === "web") as WebServer;
+  // @ts-expect-error reset private field for testing
+  web.shuttingDown = false;
+  await web.start();
+  // @ts-expect-error set private field for testing
+  web.shuttingDown = true;
+
+  try {
+    // Attempt a raw HTTP upgrade request - should get 503
+    const res = await fetch(serverUrl(), {
+      headers: {
+        Upgrade: "websocket",
+        Connection: "Upgrade",
+        "Sec-WebSocket-Key": btoa(crypto.randomUUID()),
+        "Sec-WebSocket-Version": "13",
+      },
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.text()).toBe("Server is shutting down");
+  } finally {
+    // @ts-expect-error reset private field for testing
+    web.shuttingDown = false;
+  }
+});

--- a/packages/keryx/config/server/web.ts
+++ b/packages/keryx/config/server/web.ts
@@ -44,6 +44,7 @@ export const configServerWeb = {
     "WS_MAX_SUBSCRIPTIONS",
     100,
   ),
+  websocketDrainTimeout: await loadFromEnvIfSet("WS_DRAIN_TIMEOUT", 5000),
   includeStackInErrors: await loadFromEnvIfSet(
     "WEB_SERVER_INCLUDE_STACK_IN_ERRORS",
     (Bun.env.NODE_ENV ?? "development") !== "production",


### PR DESCRIPTION
## Summary

Closes #164

- On shutdown, sends WebSocket close frames with code `1001` (Going Away) and reason `"Server shutting down"` to all connected clients
- Immediately rejects new WebSocket upgrade requests with `503 Service Unavailable` once shutdown begins
- Waits up to a configurable drain timeout for clients to disconnect gracefully, then force-closes remaining connections
- Adds `websocketDrainTimeout` config option (`WS_DRAIN_TIMEOUT` env var, default 5000ms)

## Test plan

- [x] New test: verifies close reason is sent to WebSocket clients on shutdown
- [x] New test: verifies all WebSocket connections are cleaned up after drain
- [x] New test: verifies new WS upgrades are rejected with 503 during shutdown
- [x] Existing WebSocket tests still pass (rate limiting, subscriptions, origin validation)
- [x] Full CI passes (343 tests, lint, docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)