### PR TITLE
Add CLI generators (keryx generate action/initializer)

### DIFF
--- a/packages/keryx/__tests__/generate-cli.test.ts
+++ b/packages/keryx/__tests__/generate-cli.test.ts
@@ -1,0 +1,212 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const keryxTs = path.join(import.meta.dir, "..", "keryx.ts");
+let tmpDir: string;
+let projectDir: string;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "keryx-cli-generate-"));
+
+  // Scaffold a project first so we have a valid rootDir
+  const proc = Bun.spawn(
+    ["bun", keryxTs, "new", "gen-test-app", "--no-interactive"],
+    {
+      cwd: tmpDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`keryx new failed with exit code ${exitCode}: ${stderr}`);
+  }
+
+  projectDir = path.join(tmpDir, "gen-test-app");
+});
+
+afterAll(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function runGenerate(
+  ...args: string[]
+): ReturnType<typeof Bun.spawn> & { exited: Promise<number> } {
+  return Bun.spawn(["bun", keryxTs, "generate", ...args], {
+    cwd: projectDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+describe("keryx generate action", () => {
+  test("generates a simple action", async () => {
+    const proc = runGenerate("action", "greet");
+    expect(await proc.exited).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, "actions/greet.ts"))).toBe(true);
+    expect(
+      fs.existsSync(path.join(projectDir, "__tests__/actions/greet.test.ts")),
+    ).toBe(true);
+
+    const content = fs.readFileSync(
+      path.join(projectDir, "actions/greet.ts"),
+      "utf-8",
+    );
+    expect(content).toContain('name = "greet"');
+    expect(content).toContain("class Greet implements Action");
+    expect(content).toContain('route: "/api/greet"');
+  });
+
+  test("generates a namespaced action with nested directory", async () => {
+    const proc = runGenerate("action", "user:delete");
+    expect(await proc.exited).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, "actions/user/delete.ts"))).toBe(
+      true,
+    );
+
+    const content = fs.readFileSync(
+      path.join(projectDir, "actions/user/delete.ts"),
+      "utf-8",
+    );
+    expect(content).toContain('name = "user:delete"');
+    expect(content).toContain("class UserDelete implements Action");
+    expect(content).toContain('route: "/api/user/delete"');
+  });
+});
+
+describe("keryx generate initializer", () => {
+  test("generates an initializer", async () => {
+    const proc = runGenerate("initializer", "cache");
+    expect(await proc.exited).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, "initializers/cache.ts"))).toBe(
+      true,
+    );
+
+    const content = fs.readFileSync(
+      path.join(projectDir, "initializers/cache.ts"),
+      "utf-8",
+    );
+    expect(content).toContain('const namespace = "cache"');
+    expect(content).toContain("class Cache extends Initializer");
+    expect(content).toContain('declare module "keryx"');
+  });
+});
+
+describe("keryx generate middleware", () => {
+  test("generates middleware", async () => {
+    const proc = runGenerate("middleware", "auth");
+    expect(await proc.exited).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, "middleware/auth.ts"))).toBe(
+      true,
+    );
+
+    const content = fs.readFileSync(
+      path.join(projectDir, "middleware/auth.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("export const AuthMiddleware: ActionMiddleware");
+  });
+});
+
+describe("keryx generate channel", () => {
+  test("generates a channel", async () => {
+    const proc = runGenerate("channel", "notifications");
+    expect(await proc.exited).toBe(0);
+    expect(
+      fs.existsSync(path.join(projectDir, "channels/notifications.ts")),
+    ).toBe(true);
+
+    const content = fs.readFileSync(
+      path.join(projectDir, "channels/notifications.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("class NotificationsChannel extends Channel");
+    expect(content).toContain('name: "notifications"');
+  });
+});
+
+describe("keryx generate ops", () => {
+  test("generates an ops file", async () => {
+    const proc = runGenerate("ops", "UserOps");
+    expect(await proc.exited).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, "ops/UserOps.ts"))).toBe(true);
+
+    const content = fs.readFileSync(
+      path.join(projectDir, "ops/UserOps.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("UserOps");
+  });
+});
+
+describe("keryx generate options", () => {
+  test("--dry-run does not create files", async () => {
+    const proc = runGenerate("action", "dry-run-test", "--dry-run");
+    expect(await proc.exited).toBe(0);
+    expect(
+      fs.existsSync(path.join(projectDir, "actions/dry-run-test.ts")),
+    ).toBe(false);
+
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    expect(stdout).toContain("Would create:");
+  });
+
+  test("--no-test skips test file generation", async () => {
+    const proc = runGenerate("action", "no-test-action", "--no-test");
+    expect(await proc.exited).toBe(0);
+    expect(
+      fs.existsSync(path.join(projectDir, "actions/no-test-action.ts")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(projectDir, "__tests__/actions/no-test-action.test.ts"),
+      ),
+    ).toBe(false);
+  });
+
+  test("fails on existing file without --force", async () => {
+    // First generate
+    const proc1 = runGenerate("action", "duplicate", "--no-test");
+    expect(await proc1.exited).toBe(0);
+
+    // Try again — should fail
+    const proc2 = runGenerate("action", "duplicate", "--no-test");
+    expect(await proc2.exited).toBe(1);
+
+    const stderr = await new Response(proc2.stderr as ReadableStream).text();
+    expect(stderr).toContain("already exists");
+  });
+
+  test("--force overwrites existing file", async () => {
+    const proc = runGenerate("action", "duplicate", "--force", "--no-test");
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("fails on invalid type", async () => {
+    const proc = runGenerate("widget", "foo");
+    expect(await proc.exited).toBe(1);
+
+    const stderr = await new Response(proc.stderr as ReadableStream).text();
+    expect(stderr).toContain('Unknown generator type "widget"');
+  });
+});
+
+describe("keryx g alias", () => {
+  test("g alias works for generate", async () => {
+    const proc = Bun.spawn(["bun", keryxTs, "g", "action", "alias-test"], {
+      cwd: projectDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await proc.exited).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, "actions/alias-test.ts"))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/keryx/keryx.ts
+++ b/packages/keryx/keryx.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { Action, api } from "./api";
 import pkg from "./package.json";
 import { addActionToProgram } from "./util/cli";
+import { generateComponent } from "./util/generate";
 import { globLoader } from "./util/glob";
 import {
   interactiveScaffold,
@@ -76,6 +77,51 @@ program
       process.exit(1);
     }
   });
+
+program
+  .command("generate <type> <name>")
+  .alias("g")
+  .summary("Generate a new component")
+  .description(
+    "Scaffold a new action, initializer, middleware, channel, or ops file.\n\n" +
+      "Examples:\n" +
+      "  keryx generate action user:delete\n" +
+      "  keryx generate initializer cache\n" +
+      "  keryx generate middleware auth\n" +
+      "  keryx generate channel notifications\n" +
+      "  keryx generate ops UserOps\n" +
+      "  keryx g action hello",
+  )
+  .option("--dry-run", "Show what would be generated without writing files")
+  .option("--force", "Overwrite existing files")
+  .option("--no-test", "Skip generating a test file")
+  .action(
+    async (
+      type: string,
+      name: string,
+      opts: { dryRun?: boolean; force?: boolean; test?: boolean },
+    ) => {
+      try {
+        const rootDir = process.cwd();
+        const files = await generateComponent(type, name, rootDir, {
+          dryRun: opts.dryRun,
+          force: opts.force,
+          noTest: opts.test === false,
+        });
+
+        if (!opts.dryRun) {
+          console.log("\nGenerated:");
+          files.forEach((f) => console.log(`  ${f}`));
+          console.log();
+        }
+
+        process.exit(0);
+      } catch (e) {
+        console.error((e as Error).message);
+        process.exit(1);
+      }
+    },
+  );
 
 program
   .command("start")

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/templates/generate/action-middleware.ts.mustache
+++ b/packages/keryx/templates/generate/action-middleware.ts.mustache
@@ -1,0 +1,7 @@
+import type { ActionMiddleware } from "keryx/classes/Action.ts";
+
+export const {{className}}: ActionMiddleware = {
+  runBefore: async (params, connection) => {
+    // TODO: implement
+  },
+};

--- a/packages/keryx/templates/generate/action.ts.mustache
+++ b/packages/keryx/templates/generate/action.ts.mustache
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { Action, type ActionParams } from "keryx";
+import { HTTP_METHOD } from "keryx/classes/Action.ts";
+
+export class {{className}} implements Action {
+  name = "{{name}}";
+  description = "TODO: describe this action";
+  inputs = z.object({});
+  web = { route: "{{{route}}}", method: HTTP_METHOD.GET };
+
+  async run(params: ActionParams<{{className}}>) {
+    // TODO: implement
+    return {};
+  }
+}

--- a/packages/keryx/templates/generate/channel.ts.mustache
+++ b/packages/keryx/templates/generate/channel.ts.mustache
@@ -1,0 +1,11 @@
+import { Channel, type Connection } from "keryx";
+
+export class {{className}} extends Channel {
+  constructor() {
+    super({
+      name: "{{name}}",
+      description: "TODO: describe this channel",
+      middleware: [],
+    });
+  }
+}

--- a/packages/keryx/templates/generate/initializer.ts.mustache
+++ b/packages/keryx/templates/generate/initializer.ts.mustache
@@ -1,0 +1,27 @@
+import { Initializer, api } from "keryx";
+
+const namespace = "{{name}}";
+
+declare module "keryx" {
+  export interface API {
+    [namespace]: Awaited<ReturnType<{{className}}["initialize"]>>;
+  }
+}
+
+export class {{className}} extends Initializer {
+  constructor() {
+    super(namespace);
+  }
+
+  async initialize() {
+    return {};
+  }
+
+  async start() {
+    // TODO: connect to services
+  }
+
+  async stop() {
+    // TODO: cleanup
+  }
+}

--- a/packages/keryx/templates/generate/ops.ts.mustache
+++ b/packages/keryx/templates/generate/ops.ts.mustache
@@ -1,0 +1,3 @@
+// {{className}} — business logic
+
+// TODO: implement operations

--- a/packages/keryx/templates/generate/test.ts.mustache
+++ b/packages/keryx/templates/generate/test.ts.mustache
@@ -1,0 +1,16 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { api } from "keryx";
+
+beforeAll(async () => {
+  await api.start();
+});
+
+afterAll(async () => {
+  await api.stop();
+});
+
+describe("{{name}}", () => {
+  test("TODO: implement", async () => {
+    // TODO: implement
+  });
+});

--- a/packages/keryx/util/generate.ts
+++ b/packages/keryx/util/generate.ts
@@ -1,0 +1,169 @@
+import fs from "fs";
+import Mustache from "mustache";
+import path from "path";
+
+const VALID_TYPES = [
+  "action",
+  "initializer",
+  "middleware",
+  "channel",
+  "ops",
+] as const;
+type GeneratorType = (typeof VALID_TYPES)[number];
+
+export interface GenerateOptions {
+  dryRun?: boolean;
+  force?: boolean;
+  noTest?: boolean;
+}
+
+const templatesDir = path.join(import.meta.dir, "..", "templates", "generate");
+
+async function loadTemplate(name: string): Promise<string> {
+  return Bun.file(path.join(templatesDir, name)).text();
+}
+
+/**
+ * Convert a colon-separated name to PascalCase class name.
+ * e.g. "user:delete" → "UserDelete", "hello" → "Hello"
+ */
+function toClassName(name: string): string {
+  return name
+    .split(":")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join("");
+}
+
+/**
+ * Determine the directory and filename for a component type + name.
+ * Actions with colons get nested: "user:delete" → "actions/user/delete.ts"
+ * Others are flat: "cache" → "initializers/cache.ts"
+ */
+function resolveFilePath(type: GeneratorType, name: string): string {
+  const dirMap: Record<GeneratorType, string> = {
+    action: "actions",
+    initializer: "initializers",
+    middleware: "middleware",
+    channel: "channels",
+    ops: "ops",
+  };
+
+  const baseDir = dirMap[type];
+  const segments = name.split(":");
+
+  if (segments.length > 1) {
+    // "user:delete" → "actions/user/delete.ts"
+    const fileName = segments.pop()!;
+    return path.join(baseDir, ...segments, `${fileName}.ts`);
+  }
+
+  return path.join(baseDir, `${name}.ts`);
+}
+
+/**
+ * Determine the test file path for a component.
+ * "user:delete" action → "__tests__/actions/user/delete.test.ts"
+ */
+function resolveTestPath(type: GeneratorType, name: string): string {
+  const componentPath = resolveFilePath(type, name);
+  const parsed = path.parse(componentPath);
+  return path.join("__tests__", parsed.dir, `${parsed.name}.test.ts`);
+}
+
+/**
+ * Derive the web route from an action name.
+ * "hello" → "/api/hello", "user:delete" → "/api/user/delete"
+ */
+function toRoute(name: string): string {
+  return "/api/" + name.replace(/:/g, "/");
+}
+
+/**
+ * Generate a component file (and optionally a test file).
+ * @param type The component type to generate
+ * @param name The component name (e.g., "user:delete", "cache")
+ * @param rootDir The project root directory
+ * @param options Generation options (dry-run, force, no-test)
+ * @returns List of created (or would-be-created) file paths
+ */
+export async function generateComponent(
+  type: string,
+  name: string,
+  rootDir: string,
+  options: GenerateOptions = {},
+): Promise<string[]> {
+  if (!VALID_TYPES.includes(type as GeneratorType)) {
+    throw new Error(
+      `Unknown generator type "${type}". Valid types: ${VALID_TYPES.join(", ")}`,
+    );
+  }
+
+  const generatorType = type as GeneratorType;
+  const filePath = resolveFilePath(generatorType, name);
+  const fullPath = path.join(rootDir, filePath);
+  const createdFiles: string[] = [];
+
+  // Check for conflicts
+  if (!options.force && fs.existsSync(fullPath)) {
+    throw new Error(
+      `File already exists: ${filePath}. Use --force to overwrite.`,
+    );
+  }
+
+  // Build template view
+  let className = toClassName(name);
+  if (generatorType === "middleware") className += "Middleware";
+  if (generatorType === "channel") className += "Channel";
+
+  const view: Record<string, string> = { name, className };
+  if (generatorType === "action") {
+    view.route = toRoute(name);
+  }
+
+  // Determine template
+  const templateMap: Record<GeneratorType, string> = {
+    action: "action.ts.mustache",
+    initializer: "initializer.ts.mustache",
+    middleware: "action-middleware.ts.mustache",
+    channel: "channel.ts.mustache",
+    ops: "ops.ts.mustache",
+  };
+
+  const template = await loadTemplate(templateMap[generatorType]);
+  const content = Mustache.render(template, view);
+
+  if (options.dryRun) {
+    console.log(`Would create: ${filePath}`);
+    console.log("---");
+    console.log(content);
+    createdFiles.push(filePath);
+  } else {
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    await Bun.write(fullPath, content);
+    createdFiles.push(filePath);
+  }
+
+  // Generate test file
+  if (!options.noTest) {
+    const testPath = resolveTestPath(generatorType, name);
+    const testFullPath = path.join(rootDir, testPath);
+
+    if (!options.force && fs.existsSync(testFullPath)) {
+      // Silently skip test file if it already exists
+    } else {
+      const testTemplate = await loadTemplate("test.ts.mustache");
+      const testContent = Mustache.render(testTemplate, view);
+
+      if (options.dryRun) {
+        console.log(`Would create: ${testPath}`);
+        createdFiles.push(testPath);
+      } else {
+        fs.mkdirSync(path.dirname(testFullPath), { recursive: true });
+        await Bun.write(testFullPath, testContent);
+        createdFiles.push(testPath);
+      }
+    }
+  }
+
+  return createdFiles;
+}


### PR DESCRIPTION
## Summary
- Adds `keryx generate <type> <name>` (aliased as `keryx g`) to scaffold individual component files
- Supports 5 component types: action, initializer, middleware, channel, ops
- Each generator produces a well-structured file with correct imports and class boilerplate, plus an optional test file
- Supports `--dry-run`, `--force`, and `--no-test` flags
- Bumps package version from 0.6.0 to 0.7.0

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)