### PR TITLE
Highlight observability and logging features

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,9 @@ features:
   - icon: "\U0001F5C4\uFE0F"
     title: Drizzle ORM
     details: First-class database support with auto-migrations and type-safe schemas. No separate ORM plugin needed — it's part of the stack.
+  - icon: "\U0001F4CA"
+    title: Observability & Structured Logging
+    details: Built-in OpenTelemetry metrics, plus structured logging for log aggregation. Correlation IDs trace requests across services.
 ---
 
 <!--@include: ../README.md-->


### PR DESCRIPTION
Added a new feature box to the docs landing page showcasing observability capabilities. The box highlights OpenTelemetry metrics with Prometheus scrape endpoint, structured JSON logging for production log aggregation, and correlation IDs for distributed request tracing across services.

This makes the observability and logging features—both added in recent releases—discoverable on the main landing page alongside other core capabilities.