### PR TITLE
Add sessionId to Connection for WebSocket session handling

### DIFF
--- a/packages/keryx/__tests__/classes/Connection.test.ts
+++ b/packages/keryx/__tests__/classes/Connection.test.ts
@@ -94,6 +94,67 @@ describe("Connection class", () => {
     expect(conn.rawConnection).toBe(rawConn);
   });
 
+  test("sessionId defaults to id when not provided", () => {
+    const conn = new Connection("test", "test-session-default");
+    expect(conn.sessionId).toBe(conn.id);
+  });
+
+  test("sessionId defaults to custom id when not provided", () => {
+    const conn = new Connection("test", "test-session-custom-id", "my-id");
+    expect(conn.id).toBe("my-id");
+    expect(conn.sessionId).toBe("my-id");
+  });
+
+  test("sessionId can differ from id", () => {
+    const conn = new Connection(
+      "websocket",
+      "test-ws",
+      "connection-uuid",
+      undefined,
+      "session-cookie-value",
+    );
+    expect(conn.id).toBe("connection-uuid");
+    expect(conn.sessionId).toBe("session-cookie-value");
+  });
+
+  test("connections with different ids but same sessionId share a session", async () => {
+    const sessionCookie = "shared-session-cookie";
+
+    // Simulate a WebSocket connection with unique id but shared sessionId
+    const wsConn = new Connection(
+      "websocket",
+      "127.0.0.1",
+      "ws-unique-id",
+      undefined,
+      sessionCookie,
+    );
+
+    // Create a session via the WebSocket connection
+    await api.session.create(wsConn, { userId: 42 });
+
+    // Simulate an HTTP connection with a different unique id but same sessionId
+    const httpConn = new Connection(
+      "web",
+      "127.0.0.1",
+      sessionCookie,
+      undefined,
+    );
+
+    // HTTP connection should find the same session
+    const session = await api.session.load(httpConn);
+    expect(session).toBeDefined();
+    expect(session?.data.userId).toBe(42);
+
+    // Both connections should coexist in the map
+    expect(api.connections.connections.get("ws-unique-id")).toBe(wsConn);
+    expect(api.connections.connections.get(sessionCookie)).toBe(httpConn);
+
+    // Destroying the HTTP connection should not remove the WebSocket connection
+    httpConn.destroy();
+    expect(api.connections.connections.get("ws-unique-id")).toBe(wsConn);
+    expect(api.connections.connections.get(sessionCookie)).toBeUndefined();
+  });
+
   test("act executes status action successfully", async () => {
     const conn = new Connection("test", "test-act-status");
     const params = new FormData();

--- a/packages/keryx/__tests__/servers/websocket.test.ts
+++ b/packages/keryx/__tests__/servers/websocket.test.ts
@@ -161,6 +161,48 @@ test("limits max subscriptions per connection", async () => {
   }
 });
 
+test("WebSocket connection survives concurrent HTTP requests", async () => {
+  const { socket, messages } = await buildWebSocket();
+
+  // Send a WebSocket action to confirm it works
+  socket.send(
+    JSON.stringify({
+      messageType: "action",
+      action: "status",
+      messageId: 1,
+      params: {},
+    }),
+  );
+  while (messages.length === 0) await Bun.sleep(10);
+  expect(JSON.parse(messages[0].data).response.name).toBe("test-server");
+
+  // Make concurrent HTTP requests (simulates what the frontend ChatPage does
+  // when it fetches messages via REST while the WebSocket is open)
+  await Promise.all([
+    fetch(serverUrl() + "/api/status"),
+    fetch(serverUrl() + "/api/status"),
+    fetch(serverUrl() + "/api/status"),
+  ]);
+
+  // WebSocket should still work after the HTTP requests complete
+  socket.send(
+    JSON.stringify({
+      messageType: "action",
+      action: "status",
+      messageId: 2,
+      params: {},
+    }),
+  );
+
+  while (messages.length < 2) await Bun.sleep(10);
+  const secondResponse = JSON.parse(messages[1].data);
+  expect(secondResponse.messageId).toBe(2);
+  expect(secondResponse.response.name).toBe("test-server");
+  expect(secondResponse.error).toBeUndefined();
+
+  socket.close();
+});
+
 test("rejects WebSocket upgrade with disallowed Origin header", async () => {
   const originalOrigins = config.server.web.allowedOrigins;
   (config.server.web as any).allowedOrigins = "http://allowed.example.com";

--- a/packages/keryx/classes/Connection.ts
+++ b/packages/keryx/classes/Connection.ts
@@ -22,6 +22,8 @@ export class Connection<T extends Record<string, any> = Record<string, any>> {
   identifier: string;
   /** Unique connection ID (UUID by default). Used as the key in `api.connections`. */
   id: string;
+  /** Session ID used for Redis session lookup. Defaults to `id` but may differ for WebSocket connections where the session cookie differs from the connection map key. */
+  sessionId: string;
   /** The connection's session data, lazily loaded on first action invocation. */
   session?: SessionData<T>;
   /** Set of channel names this connection is currently subscribed to. */
@@ -42,16 +44,19 @@ export class Connection<T extends Record<string, any> = Record<string, any>> {
    * @param identifier - Human-readable identifier, typically the remote IP address.
    * @param id - Unique connection ID. Defaults to a random UUID.
    * @param rawConnection - The underlying transport handle (e.g., Bun `ServerWebSocket`).
+   * @param sessionId - Session ID for Redis session lookup. Defaults to `id`. Use a different value when the connection map key should differ from the session cookie (e.g., WebSocket connections).
    */
   constructor(
     type: string,
     identifier: string,
     id = randomUUID() as string,
     rawConnection: any = undefined,
+    sessionId?: string,
   ) {
     this.type = type;
     this.identifier = identifier;
     this.id = id;
+    this.sessionId = sessionId ?? id;
     this.sessionLoaded = false;
     this.subscriptions = new Set();
     this.rawConnection = rawConnection;

--- a/packages/keryx/initializers/session.ts
+++ b/packages/keryx/initializers/session.ts
@@ -14,18 +14,18 @@ export interface SessionData<
   data: T;
 }
 
-function getKey(connectionId: Connection["id"]) {
-  return `${prefix}:${connectionId}`;
+function getKey(sessionId: Connection["sessionId"]) {
+  return `${prefix}:${sessionId}`;
 }
 
 /**
- * Load a session from Redis by connection ID. Refreshes the TTL on access.
+ * Load a session from Redis by session ID. Refreshes the TTL on access.
  *
  * @param connection - The connection whose session to load.
  * @returns The parsed session data, or `null` if no session exists.
  */
 async function load<T extends Record<string, any>>(connection: Connection) {
-  const key = getKey(connection.id);
+  const key = getKey(connection.sessionId);
   const data = await api.redis.redis.get(key);
   if (!data) return null;
   await api.redis.redis.expire(key, config.session.ttl);
@@ -43,10 +43,10 @@ async function create<T extends Record<string, any>>(
   connection: Connection,
   data = {} as T,
 ) {
-  const key = getKey(connection.id);
+  const key = getKey(connection.sessionId);
 
   const sessionData: SessionData<T> = {
-    id: connection.id,
+    id: connection.sessionId,
     cookieName: config.session.cookieName,
     createdAt: new Date().getTime(),
     data,
@@ -82,7 +82,7 @@ async function update<T extends Record<string, any>>(
  * @returns `true` if a session was deleted, `false` if none existed.
  */
 async function destroy(connection: Connection) {
-  const key = getKey(connection.id);
+  const key = getKey(connection.sessionId);
   const response = await api.redis.redis.del(key);
   return response > 0;
 }

--- a/packages/keryx/servers/web.ts
+++ b/packages/keryx/servers/web.ts
@@ -162,7 +162,12 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
       }
     }
 
-    if (server.upgrade(req, { data: { ip, id, headers, cookies } })) return; // upgrade the request to a WebSocket
+    if (
+      server.upgrade(req, {
+        data: { ip, id, wsConnectionId: randomUUID(), headers, cookies },
+      })
+    )
+      return; // upgrade the request to a WebSocket
 
     const response = await this.handleHttpRequest(req, server, ip, id);
     return compressResponse(response, req);
@@ -228,7 +233,8 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
   /** Called when a new WebSocket connection opens. Creates a `Connection` and wires up broadcast delivery. */
   handleWebSocketConnectionOpen(ws: ServerWebSocket) {
     //@ts-expect-error (ws.data is not defined in the bun types)
-    const connection = new Connection("websocket", ws.data.ip, ws.data.id, ws);
+    const { ip, id, wsConnectionId } = ws.data;
+    const connection = new Connection("websocket", ip, wsConnectionId, ws, id);
     connection.onBroadcastMessageReceived = function (payload: PubSubMessage) {
       ws.send(JSON.stringify({ message: payload }));
     };
@@ -251,7 +257,7 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
       //@ts-expect-error
       ws.data.ip,
       //@ts-expect-error
-      ws.data.id,
+      ws.data.wsConnectionId,
     );
 
     if (!connection) {
@@ -323,7 +329,7 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
       //@ts-expect-error
       ws.data.ip,
       //@ts-expect-error
-      ws.data.id,
+      ws.data.wsConnectionId,
     );
     if (!connection) return;
 


### PR DESCRIPTION
## Summary
- Adds a `sessionId` field to `Connection` that maps to the session cookie, decoupled from the connection map key
- Fixes session lookup for WebSocket connections where the cookie-based session ID differs from the connection UUID
- Updates session initializer and web server to use `sessionId` for Redis lookups
- Adds tests for the new `sessionId` behavior

## Test plan
- [ ] Existing backend tests pass (`bun test` in `packages/keryx/`)
- [ ] WebSocket connections properly resolve sessions via cookie
- [ ] HTTP connections continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)