### PR TITLE
Update CLAUDE.md and docs for recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A modern TypeScript framework built on Bun, spiritual successor to ActionHero. Monorepo with three workspaces: `packages/keryx/` (publishable framework), `example/backend/` (example API server), and `example/frontend/` (Next.js app). The core idea: **Actions are the universal controller** - they serve as HTTP endpoints, WebSocket handlers, CLI commands, background tasks, and MCP tools simultaneously.
+A modern TypeScript framework built on Bun, spiritual successor to ActionHero. Monorepo with three workspaces: `packages/keryx/` (publishable framework), `example/backend/` (example API server), and `example/frontend/` (Vite + React app). The core idea: **Actions are the universal controller** - they serve as HTTP endpoints, WebSocket handlers, CLI commands, background tasks, and MCP tools simultaneously.
 
 ## Monorepo Structure
 
 ```
-kingston/
+keryx/
   packages/keryx/          # Framework package (publishable as "keryx")
     classes/               # API, Action, Channel, Connection, Initializer, etc.
     initializers/          # Framework initializers (db, redis, actions, servers, etc.)
     servers/               # WebServer (Bun.serve)
     actions/               # Built-in actions (status, swagger)
-    config/                # Modular config with env overrides
+    config/                # Modular config with env overrides (logger, observability, server/web)
     middleware/             # Generic middleware (rateLimit)
-    util/                  # Helpers (glob, cli, config, zodMixins, oauth)
-    templates/             # OAuth HTML + SVG
+    util/                  # Helpers (glob, cli, config, zodMixins, oauth, generate, web*)
+    templates/             # OAuth HTML + SVG + CLI generator mustache templates
     lua/                   # Redis Lua scripts
     api.ts                 # Singleton + exports
     index.ts               # Package entry point (re-exports)
-    keryx.ts               # CLI entry
+    keryx.ts               # CLI entry (start, generate, upgrade)
     __tests__/             # Framework-level tests
   example/
     backend/               # Example app using keryx
@@ -37,7 +37,7 @@ kingston/
       index.ts             # Sets api.rootDir, re-exports from "keryx"
       keryx.ts             # App CLI entry
       __tests__/           # App-specific tests
-    frontend/              # Next.js frontend
+    frontend/              # Vite + React + Bootswatch frontend
   docs/                    # VitePress documentation site
 ```
 
@@ -105,7 +105,8 @@ Transport-agnostic controllers. Every action defines:
 - `web`: `{ route, method }` for HTTP routing (routes are regex or string with `:param` path params, defined on the action itself)
 - `task`: `{ queue, frequency }` for background job scheduling
 - `middleware`: Array of `ActionMiddleware` (e.g., `SessionMiddleware` for auth)
-- `run(params, connection)`: The handler. **Must throw `TypedError`** for errors.
+- `run(params, connection, abortSignal?)`: The handler. **Must throw `TypedError`** for errors. The `abortSignal` fires when the action exceeds its timeout.
+- `timeout`: Per-action timeout in ms (overrides global `config.actions.timeout`, default 300s). Set to `0` to disable.
 - `mcp`: `McpActionConfig` — `{ enabled, isLoginAction, isSignupAction }` (default `{ enabled: true }`)
 
 Type helpers: `ActionParams<A>` infers input types, `ActionResponse<A>` infers return types.
@@ -136,7 +137,7 @@ declare module "keryx" {
 }
 ```
 
-Key initializers and their priorities: `actions` (100), `db` (100), `redis` (default), `pubsub` (150), `swagger` (150), `oauth` (175), `mcp` (200/560/90), `resque` (250), `application` (1000).
+Key initializers and their priorities: `observability` (50), `actions` (100), `db` (100), `redis` (200), `pubsub` (150), `swagger` (150), `oauth` (175), `mcp` (200/560/90), `resque` (250), `application` (1000).
 
 ### Fan-Out Tasks (`packages/keryx/initializers/actionts.ts`)
 A parent action can distribute work across many child jobs using `api.actions.fanOut()`. Child results are automatically collected in Redis via `_fanOutId` injection.
@@ -161,8 +162,18 @@ Redis keys: `fanout:{id}` (hash), `fanout:{id}:results` (list), `fanout:{id}:err
 ### Channels (`packages/keryx/classes/Channel.ts`)
 PubSub channels for WebSocket real-time messaging. Channels define a `name` (string or RegExp pattern) and optional `middleware` (ChannelMiddleware) for authorization on subscribe and cleanup on unsubscribe.
 
+### Connection (`packages/keryx/classes/Connection.ts`)
+Represents a client connection across all transports. Key properties:
+- `sessionId`: Session ID for Redis session lookup (defaults to connection `id`; differs for WebSocket connections with cookie-based sessions)
+- `correlationId`: Request ID for distributed tracing (from `X-Request-Id` header or auto-generated UUID). Configured via `config.server.web.correlationId`.
+
 ### Servers (`packages/keryx/servers/web.ts`)
-WebServer uses `Bun.serve` for HTTP + WebSocket. Handles routing, static files, cookies, and session management.
+WebServer uses `Bun.serve` for HTTP + WebSocket. The server logic is split into utility modules in `packages/keryx/util/`:
+- `webRouting.ts` — route matching and HTTP request routing
+- `webSocket.ts` — WebSocket message handling and connection lifecycle
+- `webCompression.ts` — HTTP compression (Brotli, gzip) with configurable threshold
+- `webResponse.ts` — response formatting and header management
+- `webStaticFiles.ts` — static file serving with ETag/304 caching and Cache-Control headers
 
 ### MCP Server & OAuth (`packages/keryx/initializers/mcp.ts`, `packages/keryx/initializers/oauth.ts`)
 MCP (Model Context Protocol) server that exposes actions as tools for AI agents. Enabled via `MCP_SERVER_ENABLED=true`.
@@ -176,6 +187,15 @@ MCP (Model Context Protocol) server that exposes actions as tools for AI agents.
 
 ### Config (`packages/keryx/config/`)
 Modular config with per-environment overrides via `loadFromEnvIfSet()` — checks `ENV_VAR_NODEENV` first, then `ENV_VAR`, then falls back to the default value. Type-aware (auto-parses booleans and numbers).
+
+Key config files:
+- `config/server/web.ts` — port, host, CORS, `staticFiles` (cacheControl, etag), `websocket` (drainTimeout, maxPayloadSize), `compression` (enabled, threshold, encodings), `correlationId` (header, trustProxy), security headers
+- `config/logger.ts` — log level (trace→fatal), format (`text` or `json` for structured NDJSON), colorize, timestamps
+- `config/observability.ts` — `OTEL_METRICS_ENABLED`, `OTEL_METRICS_ROUTE` (`/metrics`), `OTEL_SERVICE_NAME`
+- `config/actions.ts` — global action `timeout` (default 300s)
+
+### CLI Generators (`packages/keryx/util/generate.ts`)
+`keryx generate <type> <name>` scaffolds new files from Mustache templates in `packages/keryx/templates/generate/`. Supported types: `action`, `initializer`, `middleware`, `channel`, `ops`. Each also generates a corresponding test file.
 
 ### Ops (`example/backend/ops/`)
 Business logic layer (e.g., `UserOps`, `MessageOps`) separating DB operations from actions.

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -4,7 +4,7 @@ description: Deploying Keryx — Docker, production builds, reverse proxies, and
 
 # Deployment
 
-Keryx is a backend API server. The included Next.js frontend is a demo app — in production you'll bring your own client. This guide focuses on deploying the backend.
+Keryx is a backend API server. The included Vite + React frontend is a demo app — in production you'll bring your own client. This guide focuses on deploying the backend.
 
 ## Production Build
 
@@ -143,3 +143,34 @@ ws.onclose = (event) => {
 ```
 
 The drain period is configurable via `WS_DRAIN_TIMEOUT` (default: 5000 ms). After the timeout, any remaining connections are forcibly closed.
+
+## Monitoring & Observability
+
+Keryx includes built-in OpenTelemetry instrumentation. Enable it and point Prometheus at your instances:
+
+```bash
+OTEL_METRICS_ENABLED=true bun run start
+```
+
+Each Keryx process serves a `/metrics` endpoint in Prometheus exposition format. Add a scrape target to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: "keryx"
+    scrape_interval: 15s
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+Because each process serves its own endpoint, **every node must be scraped individually** — metrics are not aggregated across instances. Use service discovery or list each target explicitly.
+
+For production log aggregation, switch to structured JSON logging:
+
+```bash
+LOG_FORMAT=json bun run start
+```
+
+This outputs NDJSON with correlated fields (timestamp, level, correlation ID) that can be ingested by Elasticsearch, Datadog, Loki, or any structured log system.
+
+See the [Observability guide](/guide/observability) for the full list of available metrics and custom exporter setup.

--- a/docs/guide/initializers.md
+++ b/docs/guide/initializers.md
@@ -24,16 +24,17 @@ initialize()  →  start()  →  [running]  →  stop()
 
 Each initializer has three priority values. Lower numbers run first:
 
-| Initializer   | Load Priority | What it does                            |
-| ------------- | ------------- | --------------------------------------- |
-| `actions`     | 100           | Discovers and registers all actions     |
-| `db`          | 100           | Sets up Drizzle ORM + connection pool   |
-| `pubsub`      | 150           | Redis PubSub for real-time messaging    |
-| `swagger`     | 150           | Parses source code for OpenAPI schemas  |
-| `oauth`       | 175           | OAuth 2.1 provider for MCP auth         |
-| `mcp`         | 200           | MCP server — exposes actions as tools   |
-| `resque`      | 250           | Background task queue                   |
-| `application` | 1000          | App-specific setup (default user, etc.) |
+| Initializer     | Load Priority | What it does                                       |
+| --------------- | ------------- | -------------------------------------------------- |
+| `observability` | 50            | OpenTelemetry metrics + Prometheus scrape endpoint |
+| `actions`       | 100           | Discovers and registers all actions                |
+| `db`            | 100           | Sets up Drizzle ORM + connection pool              |
+| `pubsub`        | 150           | Redis PubSub for real-time messaging               |
+| `swagger`       | 150           | Parses source code for OpenAPI schemas             |
+| `oauth`         | 175           | OAuth 2.1 provider for MCP auth                    |
+| `mcp`           | 200           | MCP server — exposes actions as tools              |
+| `resque`        | 250           | Background task queue                              |
+| `application`   | 1000          | App-specific setup (default user, etc.)            |
 
 The defaults are `1000` for all three priorities (`loadPriority`, `startPriority`, `stopPriority`), so core framework initializers use lower values to ensure they run first.
 

--- a/docs/reference/servers.md
+++ b/docs/reference/servers.md
@@ -62,6 +62,45 @@ Action messages include `action`, `params`, and an optional `messageId` that's e
 
 The web server can serve static files from a configured directory (default: `assets/`). This is useful for serving the frontend build output or other static assets alongside the API.
 
+### HTTP Compression
+
+The web server compresses responses using Brotli or gzip when the client supports it (via `Accept-Encoding`). Compression is enabled by default for responses larger than 1024 bytes. The server prefers Brotli when available, falling back to gzip.
+
+Configure via `config.server.web.compression`:
+
+| Key         | Env Var                     | Default         | What it does                              |
+| ----------- | --------------------------- | --------------- | ----------------------------------------- |
+| `enabled`   | `WEB_COMPRESSION_ENABLED`   | `true`          | Enable/disable HTTP compression           |
+| `threshold` | `WEB_COMPRESSION_THRESHOLD` | `1024`          | Minimum response size (bytes) to compress |
+| `encodings` | —                           | `["br","gzip"]` | Supported encodings (preference order)    |
+
+### Static File Caching
+
+When static file serving is enabled, the server supports ETag-based caching and `Cache-Control` headers. If a client sends `If-None-Match` with a matching ETag, the server returns `304 Not Modified` instead of the full file.
+
+| Key                        | Env Var                           | Default                  | What it does                          |
+| -------------------------- | --------------------------------- | ------------------------ | ------------------------------------- |
+| `staticFiles.cacheControl` | `WEB_SERVER_STATIC_CACHE_CONTROL` | `"public, max-age=3600"` | Cache-Control header for static files |
+| `staticFiles.etag`         | `WEB_SERVER_STATIC_ETAG`          | `true`                   | Enable ETag generation and 304s       |
+
+### Correlation IDs
+
+Every request is assigned a correlation ID (UUID) for distributed tracing. The ID is available on `connection.correlationId` and returned in the `X-Request-Id` response header. If a reverse proxy or upstream service sends an `X-Request-Id` header, the server can trust and propagate it instead of generating a new one.
+
+| Key                        | Env Var                          | Default          | What it does                          |
+| -------------------------- | -------------------------------- | ---------------- | ------------------------------------- |
+| `correlationId.header`     | `WEB_CORRELATION_ID_HEADER`      | `"X-Request-Id"` | Header name for correlation IDs       |
+| `correlationId.trustProxy` | `WEB_CORRELATION_ID_TRUST_PROXY` | `false`          | Trust incoming correlation ID headers |
+
+### WebSocket Configuration
+
+| Key                              | Env Var                      | Default | What it does                                    |
+| -------------------------------- | ---------------------------- | ------- | ----------------------------------------------- |
+| `websocket.maxPayloadSize`       | `WS_MAX_PAYLOAD_SIZE`        | `65536` | Max message size in bytes                       |
+| `websocket.maxMessagesPerSecond` | `WS_MAX_MESSAGES_PER_SECOND` | `20`    | Rate limit per connection                       |
+| `websocket.maxSubscriptions`     | `WS_MAX_SUBSCRIPTIONS`       | `100`   | Max channel subscriptions per connection        |
+| `websocket.drainTimeout`         | `WS_DRAIN_TIMEOUT`           | `5000`  | Ms to wait for pending messages during shutdown |
+
 ### Configuration
 
 All web server settings are in `config.server.web`:


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Synced with ~20 commits of recent changes — frontend rewrite (Next.js → Vite), action timeouts/AbortSignal, Connection sessionId/correlationId, web server util module split, HTTP compression, ETag caching, observability initializer, CLI generators, structured JSON logging, and expanded config documentation
- **docs/guide/deployment.md**: Added "Monitoring & Observability" section covering Prometheus scraping and structured JSON logging in production
- **docs/guide/initializers.md**: Added `observability` (priority 50) to the initializer priority table
- **docs/reference/servers.md**: Added sections for HTTP compression, static file caching, correlation IDs, and WebSocket configuration

## Test plan

- [ ] Verify `bun lint` passes (confirmed locally)
- [ ] Review CLAUDE.md accuracy against current source
- [ ] Preview docs site with `bun docs:dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)