### PR TITLE
Reposition Keryx as "The Fullstack TypeScript Framework for MCP and APIs"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A modern TypeScript framework built on Bun, spiritual successor to ActionHero. Monorepo with three workspaces: `packages/keryx/` (publishable framework), `example/backend/` (example API server), and `example/frontend/` (Vite + React app). The core idea: **Actions are the universal controller** - they serve as HTTP endpoints, WebSocket handlers, CLI commands, background tasks, and MCP tools simultaneously.
+The fullstack TypeScript framework for MCP and APIs, built on Bun. Spiritual successor to ActionHero. Monorepo with three workspaces: `packages/keryx/` (publishable framework), `example/backend/` (example API server), and `example/frontend/` (Vite + React app). The core idea: **Actions are the universal controller** - they serve as HTTP endpoints, WebSocket handlers, CLI commands, background tasks, and MCP tools simultaneously.
 
 ## Monorepo Structure
 
@@ -271,9 +271,9 @@ bun docs:build                     # Generate reference data + build static site
 cd docs && bun run generate        # Regenerate reference JSON from backend source
 ```
 
-**Important**: When modifying backend code (actions, initializers, config, classes), consider updating the corresponding documentation in `docs/guide/` or `docs/reference/`. The reference pages (`docs/reference/actions.md`, `initializers.md`, `config.md`) are auto-generated from source via `docs/scripts/generate-docs-data.ts`, but the guide pages (`docs/guide/*.md`) are hand-written and need manual updates.
+**Important**: When modifying backend code (actions, initializers, config, classes), consider updating the corresponding documentation in `docs/guide/` or `docs/reference/`. When writing or editing documentation, follow the editorial style guide at `docs/guide/style-guide.md` — it covers voice, tone, capitalization, and formatting conventions. The reference pages (`docs/reference/actions.md`, `initializers.md`, `config.md`) are auto-generated from source via `docs/scripts/generate-docs-data.ts`, but the guide pages (`docs/guide/*.md`) are hand-written and need manual updates.
 
-The landing page includes `README.md` via VitePress markdown includes (`<!--@include: ../README.md-->`), so README changes automatically appear on the site.
+The landing page (`docs/index.md`) has its own content — it no longer includes the README.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keryx
 
-<p align="center"><strong>Keryx is the messenger of the gods, and the greatest framework for building realtime AI, CLI, and web applications.</strong></p>
+<p align="center"><strong>The fullstack TypeScript framework for MCP and APIs.</strong></p>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/evantahler/keryx/main/docs/public/images/horn.svg" alt="Keryx" width="200" />
@@ -10,7 +10,7 @@
 
 ## What is this Project?
 
-This is a modern rewrite of [ActionHero](https://www.actionherojs.com), built on [Bun](https://bun.sh). I still believe in the core ideas behind ActionHero — it was an attempt to take the best ideas from Rails and Node.js and shove them together — but the original framework needed a fresh start with modern tooling.
+This is a ground-up rewrite of [ActionHero](https://www.actionherojs.com), built on [Bun](https://bun.sh). I still believe in the core ideas behind ActionHero — it was an attempt to take the best ideas from Rails and Node.js and shove them together — but the original framework needed a fresh start with Bun, Zod, Drizzle, and first-class MCP support.
 
 The big idea: **write your controller once, and it works everywhere**. A single action class handles HTTP requests, WebSocket messages, CLI commands, background tasks, and MCP tool calls — same inputs, same validation, same middleware, same response. No duplication.
 
@@ -82,7 +82,7 @@ Same validation, same middleware chain, same `run()` method, same response shape
 - **Built-in background tasks** via [node-resque](https://github.com/actionhero/node-resque), with a [fan-out pattern](#fan-out-tasks) for parallel job processing
 - **Strongly-typed frontend integration** — `ActionResponse<MyAction>` gives the frontend type-safe API responses, no code generation needed
 - **Drizzle ORM** with auto-migrations (replacing the old `ah-sequelize-plugin`)
-- **Companion Next.js frontend** as a separate application (replacing `ah-next-plugin`)
+- **Companion Vite + React frontend** as a separate application (replacing `ah-next-plugin`)
 
 ### Why Bun?
 
@@ -99,7 +99,7 @@ TypeScript is still the best language for web APIs. But Node.js has stalled — 
 - **root** — a slim `package.json` wrapping the workspaces. `bun install` and `bun dev` work here, but you need to `cd` into each workspace for tests.
 - **packages/keryx** — the framework package (publishable)
 - **example/backend** — the example backend application
-- **example/frontend** — the example Next.js frontend
+- **example/frontend** — the example Vite + React frontend
 - **docs** — the [documentation site](https://keryxjs.com)
 
 ## Quick Start
@@ -200,7 +200,7 @@ A parent task can distribute work across many child jobs using `api.actions.fanO
 
 ## Coming from ActionHero?
 
-Keryx keeps the core ideas but rewrites everything with modern tooling. The biggest changes: unified controllers (actions = tasks = CLI commands = MCP tools), separate frontend/backend applications, Drizzle ORM, and MCP as a first-class transport.
+Keryx keeps the core ideas but rewrites everything on Bun with first-class MCP support. The biggest changes: unified controllers (actions = tasks = CLI commands = MCP tools), separate frontend/backend applications, Drizzle ORM, and MCP as a first-class transport.
 
 See the full [migration guide](https://keryxjs.com/guide/from-actionhero) for details.
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,7 +4,7 @@ import llmstxt from "vitepress-plugin-llms";
 export default defineConfig({
   title: "Keryx",
   description:
-    "The modern TypeScript API framework — transport-agnostic actions for HTTP, WebSocket, CLI, background tasks, and MCP, built on Bun.",
+    "The fullstack TypeScript framework for MCP and APIs — transport-agnostic actions for HTTP, WebSocket, CLI, background tasks, and MCP, built on Bun.",
   head: [["link", { rel: "icon", href: "/images/horn.svg" }]],
 
   themeConfig: {
@@ -57,6 +57,19 @@ export default defineConfig({
               link: "/guide/from-actionhero",
             },
           ],
+        },
+        {
+          text: "Comparisons",
+          items: [
+            {
+              text: "Framework Comparisons",
+              link: "/guide/comparisons",
+            },
+          ],
+        },
+        {
+          text: "Contributing",
+          items: [{ text: "Style Guide", link: "/guide/style-guide" }],
         },
       ],
       "/reference/": [

--- a/docs/guide/about.md
+++ b/docs/guide/about.md
@@ -8,9 +8,15 @@ description: The name, the brand, and the community behind Keryx.
 
 **Keryx** (κῆρυξ, pronounced "KEH-rüks") is ancient Greek for "herald" or "messenger" — the person who carried proclamations between gods and mortals, announced the start of games, and ensured safe passage for diplomats. In Athenian democracy, the keryx was essential: no assembly could begin without one.
 
-It fits: your actions are the message, and Keryx delivers them across every transport — HTTP, WebSocket, CLI, background tasks, and MCP.
+It fits: your [actions](/guide/actions) are the message, and Keryx delivers them across every transport — HTTP, WebSocket, CLI, background tasks, and MCP. Write your controller once, and Keryx heralds it to every client — whether that's a browser, a terminal, a background worker, or an AI agent.
 
 Read more on [Britannica](https://www.britannica.com/topic/keryx) or [Wikipedia (Kerykes)](https://en.wikipedia.org/wiki/Kerykes).
+
+## Why MCP?
+
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is the open standard for connecting AI agents to tools and data. Anthropic, OpenAI, and Google have all adopted it — it's becoming the universal interface between LLMs and backend services.
+
+Most frameworks treat MCP as an afterthought: bolt on a separate MCP server, duplicate your route handlers as tool definitions, manage a second auth layer. Keryx treats MCP as a first-class transport. Every action you write is automatically available as an MCP tool — same validation, same [middleware](/guide/middleware), same auth — with built-in OAuth 2.1 so AI agents authenticate the same way browser clients do.
 
 ## Brand Assets
 

--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -1,0 +1,66 @@
+---
+description: How Keryx compares to Hono, Elysia, NestJS, FastAPI, and Django across transports, type safety, and MCP support.
+---
+
+# Framework Comparisons
+
+Every framework makes trade-offs. Here's where Keryx sits relative to the tools you're probably evaluating.
+
+## Feature Matrix
+
+| Feature             | Keryx | Hono    | Elysia | NestJS   | FastAPI | Django   |
+| ------------------- | ----- | ------- | ------ | -------- | ------- | -------- |
+| HTTP                | yes   | yes     | yes    | yes      | yes     | yes      |
+| WebSocket           | yes   | adapter | yes    | yes      | yes     | channels |
+| CLI commands        | yes   | —       | —      | limited  | —       | yes      |
+| Background tasks    | yes   | —       | —      | Bull     | Celery  | Celery   |
+| MCP tools           | yes   | —       | —      | —        | —       | —        |
+| Unified controller  | yes   | —       | —      | —        | —       | —        |
+| Type-safe responses | yes   | yes     | yes    | partial  | yes     | —        |
+| OAuth 2.1 built-in  | yes   | —       | —      | Passport | —       | allauth  |
+
+## vs Hono
+
+Hono is excellent for edge HTTP. It runs everywhere — Cloudflare Workers, Deno, Bun, Node — and its middleware composition is elegant. If you need multi-runtime edge deployment and nothing else, use Hono.
+
+Where Keryx diverges: Hono is an HTTP router. If you need WebSocket handling, CLI commands, background tasks, and Model Context Protocol (MCP) tools from the same codebase, you're stitching together separate libraries. Keryx gives you one [action](/guide/actions) class that serves all five transports with shared validation and middleware.
+
+Hono also doesn't have a built-in task runner or database layer. Keryx includes Resque-based [background tasks](/guide/tasks) with [fan-out](/guide/tasks#fan-out), Drizzle ORM with auto-migrations, and Redis PubSub [channels](/guide/channels) out of the box.
+
+## vs Elysia
+
+Both Keryx and Elysia are Bun-native and type-safe. Elysia focuses on HTTP performance and ergonomics — its Eden Treaty for end-to-end type safety is clever, and it benchmarks well for pure HTTP workloads.
+
+Keryx takes a different bet: instead of optimizing one transport, it unifies all of them. Your `ActionResponse<T>` types flow to the frontend the same way Eden does, but your action also works as a WebSocket handler, CLI command, background task, and MCP tool without any extra code.
+
+If you're building a pure HTTP API and performance is the top priority, Elysia is a strong choice. If you need your API to also be an MCP server that AI agents can discover and call — or you want built-in task scheduling, real-time channels, and CLI generation — that's Keryx.
+
+## vs NestJS
+
+NestJS is enterprise-grade with a huge ecosystem. If you want Angular-style architecture for your backend — decorators, dependency injection, separate modules per transport — NestJS has the most mature story in TypeScript.
+
+Keryx is opinionated in a different direction. Instead of separate controllers, gateways, and processors for HTTP, WebSocket, and tasks, Keryx uses one action class for all transports. There's no DI container — the `api` singleton manages lifecycle, and initializers wire up services with explicit priority ordering.
+
+NestJS also has no MCP story. If you need your API to double as an MCP server for AI agents, you're on your own. Keryx treats MCP as a first-class transport with built-in OAuth 2.1 authentication.
+
+The trade-off: NestJS has more community packages and a larger hiring pool. Keryx has less ceremony and fewer files per feature.
+
+## vs FastAPI
+
+FastAPI set the bar for type-safe API frameworks. Pydantic validation, automatic OpenAPI docs, async by default — it proved that a modern web framework should validate inputs at the boundary and generate documentation for free.
+
+Keryx brings that same developer experience to TypeScript. Zod schemas validate inputs, generate OpenAPI docs, power CLI `--help` text, and define MCP tool parameters — all from one definition. If you liked FastAPI's approach but work in TypeScript, Keryx is the closest equivalent.
+
+The difference: FastAPI is HTTP-only by default. WebSocket support exists but it's separate from your route handlers. Background tasks need Celery. CLI tools need Typer. MCP needs a separate server. Keryx ships all of these as built-in transports on a single action class.
+
+## vs Django
+
+Django is batteries-included for web applications — admin panel, ORM, template engine, auth system, the works. It's the right choice for server-rendered apps where you want a proven, stable foundation.
+
+Keryx is batteries-included for APIs and MCP. No template engine, no admin panel — instead you get transport-agnostic controllers, real-time WebSocket channels, background task scheduling, and an MCP server that lets AI agents call your API through the Model Context Protocol.
+
+Different tools for different jobs. Django for server-rendered web apps with decades of stability. Keryx for API-first backends that need AI agent integration alongside traditional HTTP and WebSocket clients.
+
+## The Honest Answer
+
+If you're building an HTTP-only API, any of these frameworks will serve you well. Keryx shines when you need your API to also be a WebSocket server, a CLI tool, a background task runner, and an MCP server — without writing the same logic five times.

--- a/docs/guide/from-actionhero.md
+++ b/docs/guide/from-actionhero.md
@@ -4,7 +4,7 @@ description: Key differences between Keryx and ActionHero, and what to expect wh
 
 # Coming from ActionHero
 
-Keryx is the spiritual successor to [ActionHero](https://www.actionherojs.com). It keeps the core ideas — transport-agnostic controllers, built-in background tasks, real-time channels — but rewrites everything with modern tooling. If you've used ActionHero before, here's what changed and why.
+Keryx is the spiritual successor to [ActionHero](https://www.actionherojs.com). It keeps the core ideas — transport-agnostic controllers, built-in background tasks, real-time channels — but rewrites everything on Bun with first-class MCP support, Zod validation, and Drizzle ORM. If you've used ActionHero before, here's what changed and why.
 
 ## Unified Controllers
 
@@ -12,7 +12,7 @@ The biggest structural change: actions, tasks, and CLI commands are the same thi
 
 ## Separate Applications
 
-The frontend and backend are separate Bun applications. No `ah-next-plugin` — the Next.js app is its own project in `frontend/`. Deploy them independently: frontend on Vercel, backend on a VPS, whatever works. They share types but not a process.
+The frontend and backend are separate Bun applications. No `ah-next-plugin` — the Vite + React app is its own project in `frontend/`. Deploy them independently: frontend on Vercel, backend on a VPS, whatever works. They share types but not a process.
 
 ## Routes on Actions
 
@@ -58,4 +58,4 @@ Cookie-based sessions stored in Redis are a first-class part of the framework. `
 
 - **No Pidfiles** — Process management is left to your deployment tooling (systemd, Docker, etc.)
 - **No Cache Layer** — The old ActionHero cache has been removed. Use Redis directly — it's already part of the stack.
-- **No `ah-*-plugin` pattern** — Functionality that was previously in plugins (Sequelize, Next.js) is built in or handled as a separate application.
+- **No `ah-*-plugin` pattern** — Functionality that was previously in plugins (Sequelize, Next.js) is built in or handled as a separate application (the example frontend is now Vite + React).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,9 +4,9 @@ description: Get up and running with Keryx — prerequisites, installation, and 
 
 # Getting Started
 
-Keryx is a modern rewrite of [ActionHero](https://www.actionherojs.com), rebuilt from scratch on [Bun](https://bun.sh). I still believe in the core ideas behind ActionHero — transport-agnostic actions, built-in background tasks, strong typing between frontend and backend — but the original framework was showing its age. This project takes those ideas and pairs them with modern tooling: Bun for the runtime, Zod for validation, Drizzle for the ORM, and Next.js for the frontend.
+Keryx is the fullstack TypeScript framework for MCP and APIs. It's the spiritual successor to [ActionHero](https://www.actionherojs.com), rebuilt from scratch on [Bun](https://bun.sh) with Zod for validation, Drizzle for the ORM, and a Vite + React frontend. The core ideas are the same — transport-agnostic actions, built-in background tasks, strong typing between frontend and backend — but the tooling and scope are different.
 
-The result is a full-stack monorepo template where you write your controller logic once, and it works as an HTTP endpoint, WebSocket handler, CLI command, and background task… all at the same time.
+Write your controller logic once, and it works as an HTTP endpoint, WebSocket handler, CLI command, background task, and MCP tool — all at the same time.
 
 The name **Keryx** (κῆρυξ) comes from ancient Greek, meaning "herald" or "messenger" — the person who carried proclamations between gods and mortals. It fits: your actions are the message, and Keryx delivers them across every transport.
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -48,7 +48,7 @@ OTEL_METRICS_ENABLED=true bun run start
 | `keryx.action.executions` | Counter        | action, status | Total action executions   |
 | `keryx.action.duration`   | Histogram (ms) | action         | Action execution duration |
 
-Action metrics are recorded for all transports (HTTP, WebSocket, tasks, internal).
+Action metrics are recorded for all transports (HTTP, WebSocket, CLI, background tasks, and MCP).
 
 ### Background Tasks
 

--- a/docs/guide/style-guide.md
+++ b/docs/guide/style-guide.md
@@ -1,0 +1,74 @@
+---
+description: Editorial style guide for Keryx documentation — voice, tone, capitalization, and formatting conventions.
+---
+
+# Docs Style Guide
+
+This page is for anyone writing or editing Keryx documentation. Follow these conventions to keep the docs consistent.
+
+## Naming & Capitalization
+
+- **Keryx** — Always capitalized, used as a bare proper noun (like "Rails" or "Bun"), never "the Keryx" or "the Keryx framework" in prose
+- **action / initializer / channel / middleware** — Lowercase in prose when referring to the concept or an instance ("write an action," "each initializer runs in order"). Capitalize only when referring to the class name directly, and use backticks: "the `Action` class," "extends `Initializer`"
+- **MCP** — "an MCP tool" (not "a MCP" — the M is pronounced "em"). Spell out "Model Context Protocol" on first mention per page, then use "MCP" thereafter
+- **WebSocket** — Capital W, capital S, one word. Never "Websocket," "websocket," or "web socket"
+- **Bun, Zod, Drizzle, Redis, PostgreSQL** — Always capitalized as proper nouns
+- **OAuth** — Capital O, capital A. "OAuth 2.1" with a space before the version
+
+## Transport Lists
+
+When listing all transports, use this canonical order: **HTTP, WebSocket, CLI, background tasks, and MCP**. Always include the Oxford comma.
+
+## Code Terms in Prose
+
+Use backticks for:
+
+- Class names (`Action`, `Initializer`)
+- Type names (`ActionParams<T>`, `ActionResponse<T>`)
+- Property names (`web`, `inputs`, `task`)
+- Method names (`run()`, `initialize()`)
+- Config paths (`config.server.web.port`)
+- File names (`keryx.ts`)
+
+Don't use backticks for:
+
+- General concepts (action, initializer, middleware)
+- Transport names (HTTP, WebSocket)
+- Tool names (Bun, Zod, Redis)
+
+## Voice & Tone
+
+**The voice:** An opinionated practitioner. You've built enough projects to know what works and what doesn't, and you're not shy about saying so. The tone is confident and prescriptive — earned through experience, not arrogance. Think: a senior engineer who's shipped real systems explaining things at a whiteboard. Knowledgeable but never lecturing.
+
+**Earned snark is welcome.** If there's a common anti-pattern or a "don't do this" moment, say it plainly. The reader respects directness because the opinion is backed by real scars. But snark should punch at bad ideas, never at the reader.
+
+Good examples:
+
+- "You don't need a separate routes file. The route lives on the action — where you'll actually look for it six months from now."
+- "Most frameworks make you write the same handler five times for five transports. That's not DRY, that's a staffing plan."
+- "Middleware is powerful. It's also the first place people over-engineer. A simple `if` check in your action is fine — save middleware for cross-cutting concerns."
+
+Bad examples (avoid):
+
+- "Obviously, you should..." (condescending)
+- "As any experienced developer knows..." (gatekeeping)
+- "Simply do X" (nothing is simple if you're reading the docs)
+
+**Perspective:** Strictly "you" (the reader). Avoid "we" — the focus is on what you're building, not on what the framework authors decided over lunch. The exception is the [About](/guide/about) page, which can use "we" when referring to the project and community.
+
+## Grammar
+
+- **Tense:** Present tense for describing what things do ("Keryx routes the request," not "Keryx will route the request")
+- **Voice:** Active voice preferred ("the framework loads initializers" not "initializers are loaded by the framework")
+- **Oxford comma:** Always ("HTTP, WebSocket, CLI, background tasks, and MCP")
+- **Abbreviations:** Use `e.g.,` (with comma) in parenthetical examples. Spell out "for example" in running prose
+- **Contractions:** Use freely — "it's," "you'll," "doesn't." The docs should read like conversation, not a textbook
+- **"Simply" / "just" / "easy":** Avoid. If you need the docs, it's not simple yet. Describe what to do without editorializing the difficulty
+- **Links:** External links use absolute URLs. Internal links use relative paths (`/guide/actions`). Link text should be descriptive (not "click here")
+
+## Page Structure
+
+- Every guide page should have a YAML frontmatter `description` field
+- First mention of another Keryx concept should link to its guide page
+- Code examples should be practical and runnable, not toy examples
+- Lead with the "what" and "why," then show the code. Don't dump a code block without context

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
 layout: home
-description: A modern TypeScript API framework built on Bun — the spiritual successor to ActionHero.
+description: The fullstack TypeScript framework for MCP and APIs — transport-agnostic actions for HTTP, WebSocket, CLI, background tasks, and MCP, built on Bun.
 hero:
   name: Keryx
-  text: The Modern TypeScript API Framework
-  tagline: Write one action. It handles HTTP, WebSocket, CLI, background tasks, and MCP tool calls. Built on Bun, powered by Zod, backed by Redis and Postgres.
+  text: The Fullstack TypeScript Framework for MCP and APIs
+  tagline: One action class. Five transports. Your API is automatically an MCP server, WebSocket handler, CLI tool, and background task runner. Built on Bun, powered by Zod.
   image:
     src: /images/hearald.svg
     alt: Keryx herald
@@ -22,24 +22,24 @@ hero:
       text: LLMs.txt
       link: /llms.txt
 features:
+  - icon: "\U0001F916"
+    title: MCP-Native
+    details: Every action is automatically an MCP tool. AI agents discover and call your API through the Model Context Protocol — with OAuth 2.1 auth and llms.txt support.
   - icon: "\U0001F500"
     title: One Action, Every Transport
-    details: Write your controller once — it works as an HTTP endpoint, WebSocket handler, CLI command, background task, and MCP tool simultaneously.
-  - icon: "\u26A1"
-    title: Built on Bun
-    details: Native TypeScript, fast startup, built-in test runner, no compilation step. Bun handles bundling, testing, and module resolution out of the box.
+    details: Write your controller once — HTTP endpoint, WebSocket handler, CLI command, background task, and MCP tool. Same validation, same middleware, same response.
   - icon: "\U0001F6E1\uFE0F"
     title: Zod Validation
     details: Type-safe inputs with automatic validation. Your Zod schemas generate OpenAPI docs, power CLI --help, and validate WebSocket params — all from one definition.
+  - icon: "\u26A1"
+    title: Built on Bun
+    details: Native TypeScript, fast startup, built-in test runner, no compilation step. Bun handles bundling, testing, and module resolution out of the box.
   - icon: "\U0001F4E1"
     title: Real-Time Channels
     details: PubSub over Redis with middleware-based authorization. Define channel patterns, control who can subscribe, and broadcast to WebSocket clients.
   - icon: "\u2699\uFE0F"
     title: Background Tasks & Fan-Out
     details: Built-in Resque workers with a fan-out pattern for distributing work across child jobs. Track progress and collect results automatically.
-  - icon: "\U0001F916"
-    title: MCP & llms.txt
-    details: Expose every action as an MCP tool for AI agents with OAuth 2.1 auth. This site also serves llms.txt and llms-full.txt so agents can read the full docs.
   - icon: "\U0001F5C4\uFE0F"
     title: Drizzle ORM
     details: First-class database support with auto-migrations and type-safe schemas. No separate ORM plugin needed — it's part of the stack.
@@ -48,4 +48,122 @@ features:
     details: Built-in OpenTelemetry metrics, plus structured logging for log aggregation. Correlation IDs trace requests across services.
 ---
 
-<!--@include: ../README.md-->
+## One Action, Every Transport
+
+This is one action:
+
+```ts
+export class UserCreate implements Action {
+  name = "user:create";
+  description = "Create a new user";
+  inputs = z.object({
+    name: z.string().min(3),
+    email: z.string().email(),
+    password: secret(z.string().min(8)),
+  });
+  web = { route: "/user", method: HTTP_METHOD.PUT };
+  task = { queue: "default" };
+
+  async run(params: ActionParams<UserCreate>) {
+    const user = await createUser(params);
+    return { user: serializeUser(user) };
+  }
+}
+```
+
+That one class gives you:
+
+**HTTP** — `PUT /api/user` with JSON body, query params, or form data:
+
+```bash
+curl -X PUT http://localhost:8080/api/user \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Evan","email":"evan@example.com","password":"secret123"}'
+```
+
+**WebSocket** — send a JSON message over an open connection:
+
+```json
+{
+  "messageType": "action",
+  "action": "user:create",
+  "params": {
+    "name": "Evan",
+    "email": "evan@example.com",
+    "password": "secret123"
+  }
+}
+```
+
+**CLI** — flags are generated from the Zod schema automatically:
+
+```bash
+./keryx.ts "user:create" --name Evan --email evan@example.com --password secret123 -q | jq
+```
+
+**Background Task** — enqueued to a Resque worker via Redis:
+
+```ts
+await api.actions.enqueue("user:create", {
+  name: "Evan",
+  email: "evan@example.com",
+  password: "secret123",
+});
+```
+
+**MCP** — exposed as a tool for AI agents automatically:
+
+```json
+{
+  "mcpServers": {
+    "my-app": {
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+Same validation, same middleware chain, same `run()` method, same response shape. The only thing that changes is how the request arrives and how the response is delivered.
+
+## Why Keryx?
+
+Most backends start simple — an HTTP framework — then bolt on a WebSocket server, a CLI tool, a job queue, and now an MCP layer. Each one has its own handler, its own validation, its own auth. You end up maintaining five implementations of the same logic.
+
+Keryx flips that: write your controller once, and the framework delivers it across every transport.
+
+| Feature             | Keryx | Hono    | Elysia | NestJS   | FastAPI | Django   |
+| ------------------- | ----- | ------- | ------ | -------- | ------- | -------- |
+| HTTP                | yes   | yes     | yes    | yes      | yes     | yes      |
+| WebSocket           | yes   | adapter | yes    | yes      | yes     | channels |
+| CLI commands        | yes   | —       | —      | limited  | —       | yes      |
+| Background tasks    | yes   | —       | —      | Bull     | Celery  | Celery   |
+| MCP tools           | yes   | —       | —      | —        | —       | —        |
+| Unified controller  | yes   | —       | —      | —        | —       | —        |
+| Type-safe responses | yes   | yes     | yes    | partial  | yes     | —        |
+| OAuth 2.1 built-in  | yes   | —       | —      | Passport | —       | allauth  |
+
+[See detailed comparisons →](/guide/comparisons)
+
+## Why Bun?
+
+- **Native TypeScript** — no compilation step, no `tsconfig` gymnastics
+- **Built-in test runner** — `bun test` with watch mode, no extra dependencies
+- **Fast startup** — sub-second cold starts for dev and production
+- **Module resolution that works** — ESM, CommonJS, and `.ts` imports without configuration
+- **`fetch` included natively** — great for testing your own API
+
+## Quick Start
+
+```bash
+bunx keryx new my-app
+cd my-app
+cp .env.example .env
+bun install
+bun dev
+```
+
+Requires Bun, PostgreSQL, and Redis. See the [Getting Started guide](/guide/) for full setup instructions.
+
+## Built With
+
+[Bun](https://bun.sh) · [Zod](https://zod.dev) · [Drizzle](https://orm.drizzle.team) · [Redis](https://redis.io) · [PostgreSQL](https://www.postgresql.org) · [OpenTelemetry](https://opentelemetry.io)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "module": "index.ts",
   "type": "module",
   "license": "MIT",
-  "description": "Keryx - the messenger of the gods. The greatest framework for building realtime AI, CLI, and web applications, and other applications too!",
+  "description": "The fullstack TypeScript framework for MCP and APIs — write one action, serve HTTP, WebSocket, CLI, background tasks, and MCP tools.",
   "workspaces": [
     "packages/keryx",
     "example/backend",

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -4,7 +4,7 @@
   "module": "index.ts",
   "type": "module",
   "license": "MIT",
-  "description": "Keryx - the messenger of the gods. The greatest framework for building realtime AI, CLI, and web applications, and other applications too!",
+  "description": "The fullstack TypeScript framework for MCP and APIs — write one action, serve HTTP, WebSocket, CLI, background tasks, and MCP tools.",
   "author": "Evan Tahler <evan@evantahler.com>",
   "repository": {
     "type": "git",
@@ -23,7 +23,11 @@
     "websocket",
     "realtime",
     "mcp",
+    "model-context-protocol",
     "cli",
+    "ai",
+    "fullstack",
+    "transport-agnostic",
     "actionhero"
   ],
   "files": [


### PR DESCRIPTION
## Summary

- **New landing page** — MCP-first hero, reordered feature cards, dedicated body sections with code examples, comparison table, and quick start (replaces README include)
- **Docs style guide** — editorial conventions for voice, tone, capitalization, transport list ordering, and code term formatting
- **Framework comparisons page** — Keryx vs Hono, Elysia, NestJS, FastAPI, and Django with feature matrix
- **Updated taglines everywhere** — README, both package.json files, CLAUDE.md, VitePress config all use "The fullstack TypeScript framework for MCP and APIs"
- **Fixed stale references** — Next.js → Vite + React, "modern tooling" → specific tools (Bun, Zod, Drizzle, MCP)
- **About page** — added "Why MCP?" section connecting MCP positioning to the project narrative
- **Sidebar** — added Comparisons and Contributing (Style Guide) sections

## Test plan

- [ ] `bun docs:build` passes cleanly (verified locally)
- [ ] Preview landing page layout with `bun docs:dev`
- [ ] Verify new sidebar sections render correctly
- [ ] Check style guide and comparisons pages for formatting
- [ ] Confirm no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)