### PR TITLE
Fix CI complete job allowing auto-merge on failure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,6 +131,12 @@ jobs:
 
   complete:
     runs-on: ubuntu-latest
+    if: always()
     needs: [compile, lint, test-package, test-example-backend, test-example-frontend, test-docs]
     steps:
-      - run: echo "Done!"
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "All jobs passed!"

--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -25,7 +25,7 @@ Hono is excellent for edge HTTP. It runs everywhere — Cloudflare Workers, Deno
 
 Where Keryx diverges: Hono is an HTTP router. If you need WebSocket handling, CLI commands, background tasks, and Model Context Protocol (MCP) tools from the same codebase, you're stitching together separate libraries. Keryx gives you one [action](/guide/actions) class that serves all five transports with shared validation and middleware.
 
-Hono also doesn't have a built-in task runner or database layer. Keryx includes Resque-based [background tasks](/guide/tasks) with [fan-out](/guide/tasks#fan-out), Drizzle ORM with auto-migrations, and Redis PubSub [channels](/guide/channels) out of the box.
+Hono also doesn't have a built-in task runner or database layer. Keryx includes Resque-based [background tasks](/guide/tasks) with [fan-out](/guide/tasks#fan-out-pattern), Drizzle ORM with auto-migrations, and Redis PubSub [channels](/guide/channels) out of the box.
 
 ## vs Elysia
 


### PR DESCRIPTION
## Summary

- The `complete` gate job was being **skipped** (not failed) when upstream jobs like `test-docs` failed. GitHub treats `SKIPPED` as satisfying required status checks, which allowed PR #197 to auto-merge despite a failing `test-docs` job.
- Added `if: always()` to the `complete` job with an explicit check for `failure` or `cancelled` results, so it actively fails instead of being skipped.
- Fixed broken anchor link in `docs/guide/comparisons.md`: `#fan-out` → `#fan-out-pattern` (the actual heading in `tasks.md`).

## Test plan

- [x] `bun test-docs` passes locally (11/11 tests, 0 failures)
- [ ] CI `complete` job should now **fail** (not skip) if any dependency fails
- [ ] Verify auto-merge is blocked when `complete` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)