### PR TITLE
Add Google Analytics to docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,7 +6,21 @@ export default defineConfig({
   title: "Keryx",
   description:
     "The fullstack TypeScript framework for MCP and APIs — transport-agnostic actions for HTTP, WebSocket, CLI, background tasks, and MCP, built on Bun.",
-  head: [["link", { rel: "icon", href: "/images/horn.svg" }]],
+  head: [
+    ["link", { rel: "icon", href: "/images/horn.svg" }],
+    [
+      "script",
+      {
+        async: "",
+        src: "https://www.googletagmanager.com/gtag/js?id=G-G4F5PLL4QD",
+      },
+    ],
+    [
+      "script",
+      {},
+      "window.dataLayer = window.dataLayer || [];\nfunction gtag(){dataLayer.push(arguments);}\ngtag('js', new Date());\ngtag('config', 'G-G4F5PLL4QD');",
+    ],
+  ],
 
   themeConfig: {
     logo: "/images/horn.svg",


### PR DESCRIPTION
Adds gtag.js integration with measurement ID G-G4F5PLL4QD to track page views and user engagement on keryxjs.com.

The script tags are injected into the VitePress head configuration, enabling GA4 analytics on all documentation pages without requiring additional setup or dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)