### PR TITLE
Upgrade docs hero font to Space Grotesk

### DIFF
--- a/docs/.vitepress/theme/HomeContent.vue
+++ b/docs/.vitepress/theme/HomeContent.vue
@@ -40,10 +40,10 @@
 }
 
 .container h2 {
-  font-family: "Inter", var(--vp-font-family-base);
+  font-family: "Space Grotesk", var(--vp-font-family-base);
   font-size: 2rem;
-  font-weight: 800;
-  letter-spacing: -0.01em;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   text-align: center;
   margin-bottom: 8px;
 }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,5 +1,5 @@
 /* ── Font ─────────────────────────────────────────────────────────── */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Space+Grotesk:wght@700&display=swap");
 
 /* ── Brand palette ────────────────────────────────────────────────── */
 :root {
@@ -48,9 +48,13 @@
 
 /* ── Typography ───────────────────────────────────────────────────── */
 .VPHero .name {
-  font-family: "Inter", var(--vp-font-family-base);
-  font-weight: 900;
-  letter-spacing: -0.02em;
+  font-family: "Space Grotesk", var(--vp-font-family-base);
+  font-weight: 700;
+  font-size: 6rem;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  overflow: visible;
+  clip-path: none;
 }
 
 .VPHero .text {


### PR DESCRIPTION
Replace the hero title font from Inter to Space Grotesk (weight 700) for a more distinctive, modern look on the landing page. Increase font size from default to 6rem for better visual impact.

## Changes
- Add Space Grotesk 700 to Google Fonts import
- Update `.VPHero .name` to use Space Grotesk 700 at 6rem with proper line-height to prevent descender clipping
- Update "Write Once, Run Everywhere" section heading to use Space Grotesk 700 for visual consistency
- Adjust letter-spacing to complement the larger font size

The tagline and all body text remain Inter for readability.