### PR TITLE
Fix TS2353 type error in db initializer

### DIFF
--- a/packages/keryx/initializers/db.ts
+++ b/packages/keryx/initializers/db.ts
@@ -111,14 +111,14 @@ export class DB extends Initializer {
    * Learn more @ https://orm.drizzle.team/kit-docs/overview
    */
   async generateMigrations() {
-    const migrationConfig = {
-      dialect: "postgresql",
+    const migrationConfig: DrizzleMigrateConfig = {
+      dialect: "postgresql" as const,
       schema: path.join("schema", "*"),
       dbCredentials: {
         url: config.database.connectionString,
       },
       out: path.join("drizzle"),
-    } satisfies DrizzleMigrateConfig;
+    };
 
     const fileContent = `export default ${JSON.stringify(migrationConfig, null, 2)}`;
     const tmpfilePath = path.join(api.rootDir, "drizzle", "config.tmp.ts");

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Replace `satisfies DrizzleMigrateConfig` with a type annotation (`const migrationConfig: DrizzleMigrateConfig`) in `initializers/db.ts`
- Add `as const` to the `"postgresql"` dialect literal so TypeScript narrows to the correct union branch
- Bump version to 0.10.5

## Problem
When a Keryx consumer runs `tsc --noEmit`, TypeScript follows imports into keryx's raw `.ts` source and hits TS2353 on the `satisfies` check. The `Config` type from `drizzle-kit@0.31.x` is a complex discriminated union that `satisfies` can't narrow correctly.

Fixes #215

## Test plan
- [x] `tsc --noEmit` passes in keryx package
- [x] `bun lint` passes across the monorepo
- [ ] Verify in a fresh `bunx keryx new` project that `tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)