### PR TITLE
Fix: Assert KeryxConfig type on globalThis.config assignment

### DIFF
--- a/packages/keryx/api.ts
+++ b/packages/keryx/api.ts
@@ -38,7 +38,7 @@ if (!globalThis.api) {
   // @ts-ignore — augmented API properties (db, redis, etc.) are set later by initializers at runtime
   globalThis.api = new API();
   globalThis.logger = globalThis.api.logger;
-  globalThis.config = Config;
+  globalThis.config = Config as KeryxConfig;
 }
 
 /** The global API singleton. All framework state (actions, db, redis, etc.) is accessed through this object. */

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Adds `as KeryxConfig` type assertion on `globalThis.config = Config` in `api.ts` to fix TS2741 when apps augment the `KeryxConfig` interface with custom config sections
- Bumps version to 0.11.2

Closes #225

## Test plan

- [x] All 480 existing tests pass
- [x] Lint clean
- [x] Verified the fix matches the suggested approach in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)