### PR TITLE
Add request-scoped metadata property to Connection

### DIFF
--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -121,6 +121,57 @@ When a client exceeds the limit, the middleware throws a `CONNECTION_RATE_LIMITE
 
 See the [Security guide](/guide/security) for configuration options and custom limit overrides.
 
+### Passing Data Between Middleware and Actions
+
+Use `connection.metadata` to pass request-scoped data from middleware to actions (or between `runBefore` and `runAfter`). Metadata is reset to `{}` at the start of each `act()` call, so long-lived connections like WebSockets won't leak state between requests.
+
+First, declare your metadata shape:
+
+```ts
+// types.ts
+import type { Membership, Project } from "./models";
+
+export type AppConnectionMeta = {
+  membership?: Membership;
+  project?: Project;
+  auditBefore?: Record<string, unknown>;
+  auditAfter?: Record<string, unknown>;
+};
+```
+
+Then use it in middleware and actions with the second generic on `Connection`:
+
+```ts
+import type { Connection } from "keryx";
+import type { AppConnectionMeta } from "../types";
+
+export const RbacMiddleware: ActionMiddleware = {
+  runBefore: async (
+    _params,
+    connection: Connection<any, AppConnectionMeta>,
+  ) => {
+    const membership = await resolveMembership(connection.session!.data.userId);
+    connection.metadata.membership = membership; // type-safe write
+  },
+};
+```
+
+```ts
+export class OrgView extends Action {
+  middleware = [SessionMiddleware, RbacMiddleware];
+
+  async run(
+    params: ActionParams<OrgView>,
+    connection: Connection<any, AppConnectionMeta>,
+  ) {
+    const membership = connection.metadata.membership; // type-safe read
+    // ...
+  }
+}
+```
+
+This replaces the old pattern of casting through `unknown` to attach properties to the connection.
+
 ### Response Enrichment
 
 `runAfter` can add data to the response. This runs after the action's `run()` method completes:

--- a/docs/reference/classes.md
+++ b/docs/reference/classes.md
@@ -50,7 +50,10 @@ Source: `backend/classes/Connection.ts`
 Represents a client connection — HTTP request, WebSocket, or CLI invocation. The connection handles action execution, session management, and channel subscriptions.
 
 ```ts
-class Connection<T extends Record<string, any> = Record<string, any>> {
+class Connection<
+  T extends Record<string, any> = Record<string, any>,
+  TMeta extends Record<string, any> = Record<string, any>,
+> {
   /** Connection type: "web", "websocket", "cli" */
   type: string;
 
@@ -60,6 +63,9 @@ class Connection<T extends Record<string, any> = Record<string, any>> {
   /** Unique connection ID (UUID) */
   id: string;
 
+  /** Session ID for Redis lookup (defaults to `id`) */
+  sessionId: string;
+
   /** Session data, typed with your session shape */
   session?: SessionData<T>;
 
@@ -68,6 +74,12 @@ class Connection<T extends Record<string, any> = Record<string, any>> {
 
   /** The underlying transport object (Bun Request, WebSocket, etc.) */
   rawConnection?: any;
+
+  /** Request correlation ID for distributed tracing */
+  correlationId?: string;
+
+  /** App-defined request-scoped metadata. Reset on each act() call. */
+  metadata: Partial<TMeta>;
 
   /** Execute an action with the given params */
   async act(
@@ -95,6 +107,8 @@ class Connection<T extends Record<string, any> = Record<string, any>> {
 ```
 
 The generic `T` parameter types your session data. For example, `Connection<{ userId: number }>` gives you typed access to `connection.session.data.userId`.
+
+The generic `TMeta` parameter types request-scoped metadata that middleware and actions share within a single `act()` call. It's reset to `{}` at the start of each invocation, so long-lived connections (like WebSockets) don't leak state between actions. See the [Middleware guide](/guide/middleware#passing-data-between-middleware-and-actions) for usage examples.
 
 ## Channel
 

--- a/packages/keryx/__tests__/classes/Connection.test.ts
+++ b/packages/keryx/__tests__/classes/Connection.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { z } from "zod";
 import { Connection, api, logger } from "../../api";
-import { Action } from "../../classes/Action";
+import { Action, type ActionMiddleware } from "../../classes/Action";
 import { LogFormat, LogLevel } from "../../classes/Logger";
 import { ErrorType } from "../../classes/TypedError";
 import { config } from "../../config";
@@ -349,6 +349,86 @@ describe("Connection class", () => {
     const conn = new Connection("test", "test-no-session");
 
     expect(conn.session).toBeUndefined();
+  });
+});
+
+describe("Connection metadata", () => {
+  test("metadata initializes as empty object", () => {
+    const conn = new Connection("test", "test-meta-init");
+    expect(conn.metadata).toEqual({});
+  });
+
+  test("metadata resets on each act() call", async () => {
+    const conn = new Connection("test", "test-meta-reset");
+    (conn.metadata as Record<string, unknown>).foo = "bar";
+
+    const params = new FormData();
+    await conn.act("status", params);
+
+    expect(conn.metadata).toEqual({});
+  });
+
+  test("metadata persists within a single act() lifecycle (middleware to action)", async () => {
+    const capturedValues: { before?: string; after?: string } = {};
+
+    const metadataMiddleware: ActionMiddleware = {
+      runBefore: async (_params, connection) => {
+        (connection.metadata as Record<string, unknown>).testKey =
+          "middleware-value";
+      },
+      runAfter: async (_params, connection) => {
+        capturedValues.after = (connection.metadata as Record<string, unknown>)
+          .testKey as string;
+      },
+    };
+
+    class MetadataTestAction extends Action {
+      constructor() {
+        super({
+          name: "test:metadata",
+          description: "Tests metadata flow",
+          middleware: [metadataMiddleware],
+        });
+      }
+
+      async run(_params: Record<string, unknown>, connection?: Connection) {
+        capturedValues.before = (
+          connection!.metadata as Record<string, unknown>
+        ).testKey as string;
+        return { ok: true };
+      }
+    }
+
+    const testAction = new MetadataTestAction();
+    api.actions.actions.push(testAction);
+
+    try {
+      const conn = new Connection("test", "test-meta-lifecycle");
+      const params = new FormData();
+      const { error } = await conn.act("test:metadata", params);
+
+      expect(error).toBeUndefined();
+      expect(capturedValues.before).toBe("middleware-value");
+      expect(capturedValues.after).toBe("middleware-value");
+    } finally {
+      api.actions.actions = api.actions.actions.filter(
+        (a: Action) => a.name !== "test:metadata",
+      );
+    }
+  });
+
+  test("metadata is typed via generic parameter", () => {
+    type AppMeta = { membership: string; auditBefore: Record<string, unknown> };
+    const conn = new Connection<Record<string, any>, AppMeta>(
+      "test",
+      "test-meta-typed",
+    );
+
+    conn.metadata.membership = "admin";
+    conn.metadata.auditBefore = { name: "old" };
+
+    expect(conn.metadata.membership).toBe("admin");
+    expect(conn.metadata.auditBefore).toEqual({ name: "old" });
   });
 });
 

--- a/packages/keryx/classes/Connection.ts
+++ b/packages/keryx/classes/Connection.ts
@@ -13,9 +13,15 @@ import { ErrorType, TypedError } from "./TypedError";
 /**
  * Represents a client connection to the server — HTTP request, WebSocket, or internal caller.
  * Each connection tracks its own session, channel subscriptions, and rate-limit state.
- * The generic `T` allows typing the session data shape for your application.
+ *
+ * @typeParam T - Shape of the session data stored in Redis (persists across requests).
+ * @typeParam TMeta - Shape of request-scoped metadata that middleware and actions can
+ *   read/write during a single `act()` call. Reset to `{}` at the start of each invocation.
  */
-export class Connection<T extends Record<string, any> = Record<string, any>> {
+export class Connection<
+  T extends Record<string, any> = Record<string, any>,
+  TMeta extends Record<string, any> = Record<string, any>,
+> {
   /** Transport type identifier (e.g., `"web"`, `"websocket"`). */
   type: string;
   /** A human-readable identifier for the connection, typically the remote IP or a session key. */
@@ -36,6 +42,8 @@ export class Connection<T extends Record<string, any> = Record<string, any>> {
   rateLimitInfo?: RateLimitInfo;
   /** Request correlation ID for distributed tracing. Propagated from the incoming `X-Request-Id` header when `config.server.web.correlationId.trustProxy` is enabled. */
   correlationId?: string;
+  /** App-defined request-scoped metadata. Reset to `{}` at the start of each `act()` call so that long-lived connections (e.g., WebSockets) don't leak state between actions. */
+  metadata: Partial<TMeta>;
 
   /**
    * Create a new connection and register it in `api.connections`.
@@ -60,6 +68,7 @@ export class Connection<T extends Record<string, any> = Record<string, any>> {
     this.sessionLoaded = false;
     this.subscriptions = new Set();
     this.rawConnection = rawConnection;
+    this.metadata = {};
 
     api.connections.connections.set(this.id, this);
   }
@@ -84,6 +93,7 @@ export class Connection<T extends Record<string, any> = Record<string, any>> {
     method: Request["method"] = "",
     url: string = "",
   ): Promise<{ response: Object; error?: TypedError }> {
+    this.metadata = {};
     const reqStartTime = new Date().getTime();
     let loggerResponsePrefix: "OK" | "ERROR" = "OK";
     let response: Object = {};

--- a/packages/keryx/index.ts
+++ b/packages/keryx/index.ts
@@ -22,6 +22,7 @@ export { HTTP_METHOD } from "./classes/Action";
 export type { ActionMiddleware } from "./classes/Action";
 export { CHANNEL_NAME_PATTERN } from "./classes/Channel";
 export type { ChannelMiddleware } from "./classes/Channel";
+export { Connection } from "./classes/Connection";
 export { LogLevel } from "./classes/Logger";
 export { ErrorStatusCodes, ErrorType, TypedError } from "./classes/TypedError";
 export type { KeryxConfig } from "./config";

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Adds a `metadata: Partial<TMeta>` property to `Connection` via a second generic parameter `TMeta` — lets middleware and actions share type-safe, request-scoped data without casting through `unknown`
- Resets `metadata` to `{}` at the start of each `act()` call so WebSocket connections don't leak state between actions
- Exports `Connection` directly from the `keryx` package entry point
- Adds 4 tests covering initialization, per-request reset, middleware→action data flow, and generic typing
- Documents the feature in the middleware guide and classes reference

Closes https://github.com/evantahler/keryx/issues/227

🤖 Generated with [Claude Code](https://claude.com/claude-code)