### PR TITLE
Fix: Place @ts-ignore on correct line for CompressionStream

### DIFF
--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/webCompression.ts
+++ b/packages/keryx/util/webCompression.ts
@@ -111,9 +111,8 @@ export async function compressResponse(
     // Compress the buffered body
     const format: Bun.CompressionFormat = encoding === "br" ? "brotli" : "gzip";
     // @ts-ignore Bun supports "brotli" as CompressionFormat but DOM lib does not
-    const stream = new Blob([body])
-      .stream()
-      .pipeThrough(new CompressionStream(format));
+    const compressionStream = new CompressionStream(format);
+    const stream = new Blob([body]).stream().pipeThrough(compressionStream);
 
     const headers = new Headers(response.headers);
     headers.set("Content-Encoding", encoding);
@@ -129,7 +128,8 @@ export async function compressResponse(
   // Content-Length is present and above threshold — stream-compress
   const format: Bun.CompressionFormat = encoding === "br" ? "brotli" : "gzip";
   // @ts-ignore Bun supports "brotli" as CompressionFormat but DOM lib does not
-  const stream = response.body.pipeThrough(new CompressionStream(format));
+  const compressionStream = new CompressionStream(format);
+  const stream = response.body.pipeThrough(compressionStream);
 
   const headers = new Headers(response.headers);
   headers.set("Content-Encoding", encoding);


### PR DESCRIPTION
## Summary

- v0.14.1 placed `@ts-ignore` on a chained call where it only suppressed the first line (`const stream = new Blob([body])`), not the `.pipeThrough(new CompressionStream(format))` line where the actual TS2345 error occurs
- Extracts `new CompressionStream(format)` onto its own line so the `@ts-ignore` directly covers the `CompressionFormat` type mismatch between Bun and DOM lib types
- Bumps version to `0.14.2`

## Test plan

- [x] `bun lint` passes (includes `tsc`)
- [x] `cd packages/keryx && bun test` — 312/312 pass
- [ ] Verify `tsc -b` in a frontend project with `"lib": ["ES2022", "DOM"]` no longer errors on `webCompression.ts`

Fixes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)