### PR TITLE
Fix: webCompression.ts ReadableStream type errors (#250)

### DIFF
--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/webCompression.ts
+++ b/packages/keryx/util/webCompression.ts
@@ -112,6 +112,7 @@ export async function compressResponse(
     const format: Bun.CompressionFormat = encoding === "br" ? "brotli" : "gzip";
     // @ts-ignore Bun supports "brotli" as CompressionFormat but DOM lib does not
     const compressionStream = new CompressionStream(format);
+    // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
     const stream = new Blob([body]).stream().pipeThrough(compressionStream);
 
     const headers = new Headers(response.headers);
@@ -119,6 +120,7 @@ export async function compressResponse(
     headers.append("Vary", "Accept-Encoding");
     headers.delete("Content-Length");
 
+    // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
     return new Response(stream, {
       status: response.status,
       headers,
@@ -129,6 +131,7 @@ export async function compressResponse(
   const format: Bun.CompressionFormat = encoding === "br" ? "brotli" : "gzip";
   // @ts-ignore Bun supports "brotli" as CompressionFormat but DOM lib does not
   const compressionStream = new CompressionStream(format);
+  // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
   const stream = response.body.pipeThrough(compressionStream);
 
   const headers = new Headers(response.headers);
@@ -136,6 +139,7 @@ export async function compressResponse(
   headers.append("Vary", "Accept-Encoding");
   headers.delete("Content-Length");
 
+  // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
   return new Response(stream, {
     status: response.status,
     headers,


### PR DESCRIPTION
## Summary

- Adds `@ts-ignore` before `pipeThrough()` and `new Response(stream, ...)` calls in both compression paths
- Bun's `ReadableStream` adds `.blob()`, `.text()`, `.bytes()`, `.json()` methods that make it incompatible with Node/DOM `ReadableStream` types
- Covers both the buffered body path (lines 115, 122) and the streaming path (lines 132, 139)
- Bumps version to `0.14.3`

## Test plan

- [x] `bun lint` passes (includes `tsc`)
- [x] `cd packages/keryx && bun test` — 312/312 pass

Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)