### PR TITLE
Fix out-of-date docs examples, incorrect defaults, and generator route bug

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -46,7 +46,7 @@ That's a fully functioning HTTP endpoint, CLI command, and WebSocket handler. Hi
 
 ## Input Validation
 
-Inputs use [Zod](https://zod.dev) schemas. If validation fails, the client gets a `422` with the validation errors — you don't need to write any error handling for bad inputs.
+Inputs use [Zod](https://zod.dev) schemas. If validation fails, the client gets a `406` with the validation errors — you don't need to write any error handling for bad inputs.
 
 ```ts
 inputs = z.object({
@@ -64,7 +64,7 @@ inputs = z.object({
 You can mark sensitive fields with the `secret()` wrapper so they're redacted as `[[secret]]` in logs. Don't log passwords — use this:
 
 ```ts
-import { secret } from "../util/zodMixins";
+import { secret } from "keryx";
 
 inputs = z.object({
   password: secret(z.string().min(8)),
@@ -194,11 +194,11 @@ import { ErrorType, TypedError } from "keryx";
 
 throw new TypedError({
   message: "User not found",
-  type: ErrorType.CONNECTION_ACTION_RUN, // → 400
+  type: ErrorType.CONNECTION_ACTION_RUN, // → 500
 });
 ```
 
-Some common mappings: `ACTION_VALIDATION` → 422, `CONNECTION_SESSION_NOT_FOUND` → 401, `CONNECTION_ACTION_NOT_FOUND` → 404.
+Some common mappings: `CONNECTION_ACTION_PARAM_VALIDATION` → 406, `CONNECTION_SESSION_NOT_FOUND` → 401, `CONNECTION_ACTION_NOT_FOUND` → 404, `CONNECTION_RATE_LIMITED` → 429.
 
 ## Registration
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -90,7 +90,7 @@ By default, every action is exposed as an MCP tool. To hide an action from agent
 ```ts
 export class InternalCleanup implements Action {
   name = "internal:cleanup";
-  mcp = { enabled: false };
+  mcp = { tool: false };
   // ...
 }
 ```
@@ -102,7 +102,7 @@ Login and signup actions used in the OAuth flow are typically hidden too:
 ```ts
 export class SessionCreate implements Action {
   name = "session:create";
-  mcp = { enabled: false, isLoginAction: true };
+  mcp = { tool: false, isLoginAction: true };
   // ...
 }
 ```
@@ -171,7 +171,7 @@ When an agent calls `listTools`, it gets a clean list of your actions:
 - **Tool names** — action names with `:` replaced by `-` (e.g., `user:create` → `user-create`)
 - **Descriptions** — from your action's `description` property
 - **Input schemas** — JSON Schema generated from your Zod `inputs`, with field descriptions from `.describe()`
-- **Typed errors** — when a tool call fails, the agent receives a structured error with an `ErrorType` (e.g., `CONNECTION_INVALID`, `VALIDATION_ERROR`) instead of a generic failure message
+- **Typed errors** — when a tool call fails, the agent receives a structured error with an `ErrorType` (e.g., `CONNECTION_ACTION_PARAM_VALIDATION`, `CONNECTION_ACTION_RUN`) instead of a generic failure message
 
 The Zod-to-JSON-Schema conversion handles edge cases automatically. Types that can't be represented in JSON Schema (like `z.date()`) fall back to `z.string()`, so tool registration never fails.
 

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -42,7 +42,7 @@ export class SessionCreate implements Action {
   name = "session:create";
   description = "Sign in with email and password";
   web = { route: "/session", method: HTTP_METHOD.PUT };
-  mcp = { enabled: false, isLoginAction: true };
+  mcp = { tool: false, isLoginAction: true };
   middleware = [RateLimitMiddleware];
   inputs = z.object({
     email: z
@@ -125,12 +125,15 @@ See the [MCP guide](/guide/mcp#oauth-21-authentication) for the full OAuth flow 
 
 ## Session Configuration
 
-| Key          | Env Var               | Default        | Description                      |
-| ------------ | --------------------- | -------------- | -------------------------------- |
-| `cookieName` | `SESSION_COOKIE_NAME` | `"session_id"` | Cookie name for session tracking |
-| `ttl`        | `SESSION_TTL`         | `86400`        | Session TTL in seconds (1 day)   |
+| Key              | Env Var                    | Default       | Description                               |
+| ---------------- | -------------------------- | ------------- | ----------------------------------------- |
+| `ttl`            | `SESSION_TTL`              | `86400`       | Session TTL in seconds (1 day)            |
+| `cookieName`     | `SESSION_COOKIE_NAME`      | `"__session"` | Cookie name for session tracking          |
+| `cookieHttpOnly` | `SESSION_COOKIE_HTTP_ONLY` | `true`        | Prevent JavaScript access                 |
+| `cookieSecure`   | `SESSION_COOKIE_SECURE`    | `false`       | HTTPS-only cookies                        |
+| `cookieSameSite` | `SESSION_COOKIE_SAME_SITE` | `"Strict"`    | CSRF protection (`Strict`, `Lax`, `None`) |
 
-Cookie security settings (Secure, SameSite, HttpOnly) are configured in the web server config. See the [Security guide](/guide/security) for production recommendations.
+See the [Security guide](/guide/security) for production recommendations on cookie security settings.
 
 ## Testing with Sessions
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -93,7 +93,7 @@ export class UserDelete implements Action {
   name = "user:delete";
   description = "TODO: describe this action";
   inputs = z.object({});
-  web = { route: "/api/user/delete", method: HTTP_METHOD.GET };
+  web = { route: "/user/delete", method: HTTP_METHOD.GET };
 
   async run(params: ActionParams<UserDelete>) {
     // TODO: implement

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -136,12 +136,13 @@ DATABASE_POOL_CONNECT_TIMEOUT=5000
 
 ### Logger
 
-| Key                 | Env Var                  | Default  | Description                                                                |
-| ------------------- | ------------------------ | -------- | -------------------------------------------------------------------------- |
-| `level`             | `LOG_LEVEL`              | `"info"` | Minimum log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`)     |
-| `includeTimestamps` | `LOG_INCLUDE_TIMESTAMPS` | `true`   | Prepend ISO-8601 timestamp to each log line                                |
-| `colorize`          | `LOG_COLORIZE`           | `true`   | Apply ANSI color codes (text format only)                                  |
-| `format`            | `LOG_FORMAT`             | `"text"` | Output format: `"text"` for human-readable, `"json"` for structured NDJSON |
+| Key                 | Env Var                  | Default  | Description                                                                           |
+| ------------------- | ------------------------ | -------- | ------------------------------------------------------------------------------------- |
+| `level`             | `LOG_LEVEL`              | `"info"` | Minimum log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`)                |
+| `includeTimestamps` | `LOG_INCLUDE_TIMESTAMPS` | `true`   | Prepend ISO-8601 timestamp to each log line                                           |
+| `colorize`          | `LOG_COLORIZE`           | `true`   | Apply ANSI color codes (text format only)                                             |
+| `format`            | `LOG_FORMAT`             | `"text"` | Output format: `"text"` for human-readable, `"json"` for structured NDJSON            |
+| `maxParamLength`    | `LOG_MAX_PARAM_LENGTH`   | `100`    | Max length of individual param values in action logs before truncation (0 = no limit) |
 
 In JSON mode, each log line is a single JSON object with `timestamp`, `level`, `message`, and `pid` fields. Action and task logs include additional structured fields like `action`, `duration`, `status`, `method`, `url`, `correlationId`, `queue`, and `jobClass` — making them easy to parse with log aggregation systems (ELK, Datadog, CloudWatch, Loki, etc.).
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -11,7 +11,7 @@ We don't mock the server. That's a deliberate choice — if you're testing an AP
 Each test file boots and stops the full server in `beforeAll`/`afterAll`. Tests use dynamic port binding (`WEB_SERVER_PORT=0`) so each file gets a random available port — no conflicts when running multiple test files:
 
 ```ts
-import { api } from "../../api";
+import { api } from "keryx";
 import { serverUrl, HOOK_TIMEOUT } from "../setup";
 
 let url: string;

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -4,7 +4,7 @@ description: Action class definition, transport behavior across HTTP/WebSocket/C
 
 # Action
 
-Source: `backend/classes/Action.ts`
+Source: `packages/keryx/classes/Action.ts`
 
 The `Action` class is the foundation of Keryx. Every controller — whether it handles HTTP, WebSocket, CLI, or background tasks — is an action. You write the logic once, and the framework handles the transport plumbing.
 

--- a/docs/reference/classes.md
+++ b/docs/reference/classes.md
@@ -8,7 +8,7 @@ The remaining framework classes — the API singleton, connections, channels, se
 
 ## API
 
-Source: `backend/classes/API.ts`
+Source: `packages/keryx/classes/API.ts`
 
 The global singleton that manages the full server lifecycle. Stored on `globalThis` so it's accessible everywhere. Initializers attach their namespaces to it during boot.
 
@@ -45,7 +45,7 @@ The lifecycle is `initialize() → start() → [running] → stop()`. Calling `s
 
 ## Connection
 
-Source: `backend/classes/Connection.ts`
+Source: `packages/keryx/classes/Connection.ts`
 
 Represents a client connection — HTTP request, WebSocket, or CLI invocation. The connection handles action execution, session management, and channel subscriptions.
 
@@ -112,7 +112,7 @@ The generic `TMeta` parameter types request-scoped metadata that middleware and 
 
 ## Channel
 
-Source: `backend/classes/Channel.ts`
+Source: `packages/keryx/classes/Channel.ts`
 
 Defines a PubSub topic for WebSocket real-time messaging. Channels support exact-match names or RegExp patterns.
 
@@ -148,7 +148,7 @@ type ChannelMiddleware = {
 
 ## Server
 
-Source: `backend/classes/Server.ts`
+Source: `packages/keryx/classes/Server.ts`
 
 Base class for transport servers. The framework ships with a web server (`Bun.serve` for HTTP + WebSocket), but you could add others.
 
@@ -167,7 +167,7 @@ abstract class Server<T> {
 
 ## TypedError
 
-Source: `backend/classes/TypedError.ts`
+Source: `packages/keryx/classes/TypedError.ts`
 
 All action errors should use `TypedError` instead of generic `Error`. Each error type maps to an HTTP status code, so the framework knows what status to return to the client.
 
@@ -195,18 +195,29 @@ class TypedError extends Error {
 | `SERVER_START`                       | 500    | Initializer failed to start                |
 | `SERVER_STOP`                        | 500    | Initializer failed to stop                 |
 | `CONFIG_ERROR`                       | 500    | Invalid configuration                      |
+| `INITIALIZER_VALIDATION`             | 500    | Initializer definition is invalid          |
 | `ACTION_VALIDATION`                  | 500    | Action class definition is invalid         |
+| `TASK_VALIDATION`                    | 500    | Task definition is invalid                 |
+| `SERVER_VALIDATION`                  | 500    | Server definition is invalid               |
 | `CONNECTION_SESSION_NOT_FOUND`       | 401    | No session / not authenticated             |
+| `CONNECTION_SERVER_ERROR`            | 500    | Internal server error                      |
 | `CONNECTION_ACTION_NOT_FOUND`        | 404    | Unknown action name                        |
 | `CONNECTION_ACTION_PARAM_REQUIRED`   | 406    | Missing required input                     |
+| `CONNECTION_ACTION_PARAM_DEFAULT`    | 406    | Default value failed to apply              |
 | `CONNECTION_ACTION_PARAM_VALIDATION` | 406    | Input failed Zod validation                |
+| `CONNECTION_ACTION_PARAM_FORMATTING` | 406    | Input formatting error                     |
 | `CONNECTION_ACTION_RUN`              | 500    | Action threw during `run()`                |
+| `CONNECTION_TYPE_NOT_FOUND`          | 406    | Unknown connection type                    |
 | `CONNECTION_NOT_SUBSCRIBED`          | 406    | Tried to broadcast to unsubscribed channel |
 | `CONNECTION_CHANNEL_AUTHORIZATION`   | 403    | Channel subscription denied                |
+| `CONNECTION_CHANNEL_VALIDATION`      | 400    | Invalid channel name                       |
+| `CONNECTION_ACTION_TIMEOUT`          | 408    | Action exceeded its timeout                |
+| `CONNECTION_RATE_LIMITED`            | 429    | Client exceeded rate limit                 |
+| `CONNECTION_TASK_DEFINITION`         | 500    | Task definition error                      |
 
 ## Logger
 
-Source: `backend/classes/Logger.ts`
+Source: `packages/keryx/classes/Logger.ts`
 
 Simple logger that writes to stdout. No Winston, no Pino — just STDOUT and STDERR with optional colors and timestamps.
 

--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -4,14 +4,14 @@ description: Zod helper utilities for secret fields, ID-or-model resolution, and
 
 # Utilities
 
-Keryx provides several Zod helper utilities in `backend/util/zodMixins.ts` for common patterns.
+Keryx provides several Zod helper utilities in `packages/keryx/util/zodMixins.ts` for common patterns. App-specific helpers like `zUserIdOrModel()` and `zMessageIdOrModel()` live in `example/backend/util/zodMixins.ts`.
 
 ## `secret(schema)`
 
 Marks a Zod schema as secret so the field is redacted as `[[secret]]` in request logs. Uses Zod v4's native `.meta()` API.
 
 ```ts
-import { secret } from "../util/zodMixins";
+import { secret } from "keryx";
 
 inputs = z.object({
   email: z.string().email(),
@@ -26,7 +26,7 @@ When a request comes in with `password: "hunter2"`, the logs will show `password
 Check if a Zod schema has been marked as secret:
 
 ```ts
-import { isSecret } from "../util/zodMixins";
+import { isSecret } from "keryx";
 
 if (isSecret(schema)) {
   // redact this field in output
@@ -38,7 +38,7 @@ if (isSecret(schema)) {
 Creates a Zod schema that accepts both boolean and string values, transforming `"true"` and `"false"` strings into actual booleans. Useful for HTML form data where booleans arrive as strings.
 
 ```ts
-import { zBooleanFromString } from "../util/zodMixins";
+import { zBooleanFromString } from "keryx";
 
 inputs = z.object({
   active: zBooleanFromString(),
@@ -98,7 +98,7 @@ inputs = z.object({
 To create a resolver for a custom table, use the `zIdOrModel` factory directly:
 
 ```ts
-import { zIdOrModel } from "../util/zodMixins";
+import { zIdOrModel } from "keryx";
 import { createSchemaFactory } from "drizzle-zod";
 import { z } from "zod";
 import { projects, type Project } from "../schema/projects";

--- a/packages/keryx/__tests__/generate-cli.test.ts
+++ b/packages/keryx/__tests__/generate-cli.test.ts
@@ -60,7 +60,7 @@ describe("keryx generate action", () => {
     );
     expect(content).toContain('name = "greet"');
     expect(content).toContain("class Greet implements Action");
-    expect(content).toContain('route: "/api/greet"');
+    expect(content).toContain('route: "/greet"');
   });
 
   test("generates a namespaced action with nested directory", async () => {
@@ -76,7 +76,7 @@ describe("keryx generate action", () => {
     );
     expect(content).toContain('name = "user:delete"');
     expect(content).toContain("class UserDelete implements Action");
-    expect(content).toContain('route: "/api/user/delete"');
+    expect(content).toContain('route: "/user/delete"');
   });
 });
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/generate.ts
+++ b/packages/keryx/util/generate.ts
@@ -75,7 +75,7 @@ function resolveTestPath(type: GeneratorType, name: string): string {
  * "hello" → "/api/hello", "user:delete" → "/api/user/delete"
  */
 function toRoute(name: string): string {
-  return "/api/" + name.replace(/:/g, "/");
+  return "/" + name.replace(/:/g, "/");
 }
 
 /**


### PR DESCRIPTION
- Fix `mcp = { enabled: false }` → `mcp = { tool: false }` in agents and auth docs
- Fix session cookie name default `"session_id"` → `"__session"` in auth docs
- Expand session config table to include all cookie security settings
- Add missing `maxParamLength` to logger config reference
- Fix incorrect HTTP status codes (422→406, 400→500) in actions doc
- Fix nonexistent ErrorType names in agents doc
- Fix `secret` and utility import paths from relative to `"keryx"` package imports
- Fix source file paths from `backend/` to `packages/keryx/` in reference docs
- Complete ErrorType → HTTP status mapping table with all 23 error types
- Fix generator `toRoute()` dropping `/api/` prefix (was causing double-prefix URLs)
- Update CLI docs and generator tests for corrected routes

https://claude.ai/code/session_012FRFteNVtMuV5yqB34i4LE