### PR TITLE
Fix invalid PreCommit hook event to TaskCompleted

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
         ]
       }
     ],
-    "PreCommit": [
+    "TaskCompleted": [
       {
         "matcher": "",
         "hooks": [


### PR DESCRIPTION
## Summary
- Replaced invalid `PreCommit` hook event with `TaskCompleted` in `.claude/settings.json`
- `PreCommit` is not a valid Claude Code hook event; `TaskCompleted` runs prettier on task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)