### PR TITLE
Add Claude Code agents: test-runner, docs-sync, pr-preflight

### DIFF
--- a/.claude/agents/docs-sync.md
+++ b/.claude/agents/docs-sync.md
@@ -1,0 +1,57 @@
+# Docs Sync
+
+Check whether documentation needs updating after backend or framework code changes.
+
+## Instructions
+
+### 1. Identify what changed
+
+Run `git diff main --name-only` (or `git diff HEAD~1 --name-only` if already on main) to get the list of changed files. Focus on:
+- `packages/keryx/` — framework code
+- `example/backend/` — example app code
+
+Ignore changes to test files, `.env` files, and the `docs/` directory itself.
+
+### 2. Map code changes to docs
+
+Use this mapping to identify which docs might need updates:
+
+| Code Area | Relevant Docs |
+|-----------|---------------|
+| `classes/Action.ts`, action files | `docs/guide/actions.md`, `docs/reference/actions.md` |
+| `classes/API.ts`, `api.ts` | `docs/reference/classes.md` |
+| Initializer files | `docs/guide/initializers.md`, `docs/reference/initializers.md` |
+| `classes/Channel.ts`, channel files | `docs/guide/channels.md` |
+| MCP/OAuth code | `docs/guide/mcp.md` |
+| Config files | `docs/guide/config.md`, `docs/reference/config.md` |
+| Server/web files | `docs/reference/servers.md` |
+| Middleware files | `docs/guide/middleware.md` |
+| Task/fan-out code | `docs/guide/tasks.md` |
+| Zod helpers, utilities | `docs/reference/utilities.md` |
+| CLI/generators | `docs/guide/cli.md` |
+| TypedError, Connection, Logger | `docs/reference/classes.md` |
+| Auth-related code | `docs/guide/authentication.md` |
+| Observability code | `docs/guide/observability.md` |
+
+### 3. Check for staleness
+
+For each relevant doc:
+1. Read the doc file
+2. Read the changed source code
+3. Compare: does the doc accurately reflect the current code?
+
+Look for:
+- **Changed signatures** — method parameters, return types, or names that differ from what the doc shows
+- **New features** — exported classes, methods, config options, or action properties not mentioned in docs
+- **Removed features** — things documented that no longer exist in code
+- **Changed defaults** — config defaults, timeout values, etc. that have been updated
+- **Incorrect examples** — code snippets in docs that would no longer work
+
+### 4. Report findings
+
+Provide a concise summary:
+
+- **Up to date**: list docs that were checked and are fine (one line each)
+- **Needs update**: for each stale doc, explain specifically what's wrong and what the correct content should be
+
+Do NOT edit docs files yourself — just report what needs changing so the user can review and decide.

--- a/.claude/agents/pr-preflight.md
+++ b/.claude/agents/pr-preflight.md
@@ -1,0 +1,70 @@
+# PR Preflight
+
+Run all pre-merge checks for a Keryx pull request. This agent validates that a branch is ready to merge.
+
+## Instructions
+
+Run these checks in order. Stop early and report if a blocking issue is found.
+
+### 1. Version bump check
+
+Read `packages/keryx/package.json` and compare the `"version"` field against the main branch:
+
+```bash
+git diff main -- packages/keryx/package.json
+```
+
+If the version has NOT been bumped, report this as a **blocking issue**. Every PR must bump the version (patch for bug fixes, minor for new features).
+
+### 2. Lint check
+
+Run from the repo root:
+
+```bash
+bun lint
+```
+
+This runs `tsc` type checking and `prettier --check` across all workspaces. Report any failures.
+
+### 3. Test check
+
+Run the full test suite:
+
+```bash
+bun tests
+```
+
+Before running, check for stale `bun keryx` processes:
+```bash
+ps aux | grep "bun keryx" | grep -v grep
+```
+
+Report any test failures with file paths and error details.
+
+### 4. Test coverage check
+
+Verify that changed code has corresponding test changes:
+
+```bash
+git diff main --name-only
+```
+
+If source files in `packages/keryx/` or `example/backend/` were modified but no test files (`__tests__/**`) were added or changed, flag this as a **warning**. Every code change should include tests.
+
+### 5. Docs sync check
+
+Use the `docs-sync` agent to check whether documentation needs updating based on the code changes in this branch. Report any findings from that agent.
+
+### 6. Summary
+
+Provide a final summary table:
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Version bump | pass/fail | current version |
+| Lint | pass/fail | error count if any |
+| Tests | pass/fail | pass/fail/skip counts |
+| Test coverage | pass/warn | list of uncovered files |
+| Docs sync | pass/warn | list of stale docs |
+
+Mark the overall result as **Ready to merge** or **Blocked** with the specific issues that need fixing.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,50 @@
+# Test Runner
+
+Run tests for one or more workspaces in the Keryx monorepo and report results.
+
+## Usage
+
+Invoke with a prompt specifying which tests to run:
+- `"Run all tests"` — runs framework + example backend + example frontend tests
+- `"Run package tests"` — runs only `packages/keryx/` tests
+- `"Run backend tests"` — runs only `example/backend/` tests
+- `"Run backend tests for user actions"` — runs a single test file
+- `"Run CI"` — runs the full CI pipeline (lint + all tests + docs tests)
+
+## Instructions
+
+### Before running tests
+
+1. Check for stale `bun keryx` processes that could cause port conflicts:
+   ```bash
+   ps aux | grep "bun keryx" | grep -v grep
+   ```
+   If any are found, report them to the user and ask before killing.
+
+2. Ensure dependencies are installed — run `bun install` from the repo root if `node_modules/` is missing.
+
+3. For backend tests, verify PostgreSQL and Redis are running locally.
+
+### Running tests
+
+Use these commands based on what was requested:
+
+| Scope | Command | Working Directory |
+|-------|---------|-------------------|
+| Full CI | `bun run ci` | repo root |
+| All tests (no lint) | `bun tests` | repo root |
+| Framework only | `bun test` | `packages/keryx/` |
+| Backend only | `bun test` | `example/backend/` |
+| Single file | `bun test __tests__/path/to/file.test.ts` | relevant workspace |
+| Frontend only | `bun test` | `example/frontend/` |
+
+### Reporting results
+
+After tests complete, provide a summary:
+
+- **Pass/fail status** for each test file that ran
+- **Total counts**: passed, failed, skipped
+- **For failures**: include the test name, assertion error, and relevant file path with line number
+- **Runtime** if available
+
+Keep the summary concise. Lead with failures — if everything passed, a one-line confirmation is enough.


### PR DESCRIPTION
## Summary
- **test-runner** — runs tests for any workspace combination, checks for stale `bun keryx` processes first, reports pass/fail summary
- **docs-sync** — maps code changes to relevant doc files, compares code vs docs, reports what's stale (research-only, no edits)
- **pr-preflight** — full pre-merge checklist: version bump, lint, tests, test coverage, and docs sync (delegates to docs-sync agent). Produces a summary table with Ready/Blocked verdict.

## Test plan
- [ ] Invoke `@test-runner Run all tests` and verify it runs the correct commands
- [ ] Invoke `@docs-sync` on a branch with code changes and verify it identifies relevant docs
- [ ] Invoke `@pr-preflight` on a branch and verify all 5 checks run, including docs-sync delegation

🤖 Generated with [Claude Code](https://claude.com/claude-code)