### PR TITLE
Refactor MCP initializer: extract helpers to util/mcpServer.ts

### DIFF
--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: refactor
+description: |
+  Refactor keryx framework or example app code while preserving behavior. Use this skill whenever the user asks to clean up, simplify, extract, inline, rename, reorganize, DRY up, decompose, or refactor code — even if they don't use the word "refactor" explicitly. Also use when moving logic between files, extracting helpers or utilities, splitting large files, or consolidating duplicated patterns.
+keywords: [refactor, extract, inline, rename, move, simplify, clean up, decompose, DRY, reorganize, split, consolidate]
+---
+
+# Refactoring Workflow
+
+Refactoring means changing code structure without changing behavior. Every step must preserve the existing test suite and public API contracts.
+
+## Phase 1: Understand Before Touching
+
+1. **Read the target code** — understand what it does, who calls it, and what depends on it
+2. **Check for tests** — find existing test coverage for the code being refactored
+   - Search in `packages/keryx/__tests__/` for framework code
+   - Search in `example/backend/__tests__/` for app code
+3. **Run the existing tests** to establish a green baseline before making changes:
+   ```bash
+   cd packages/keryx && bun test        # framework code
+   cd example/backend && bun test       # app code
+   ```
+4. **Check for stale processes** if tests behave unexpectedly:
+   ```bash
+   ps aux | grep "bun keryx" | grep -v grep
+   ```
+
+## Phase 2: Plan the Refactoring
+
+Before writing code, state the plan concisely:
+- What structural change you're making and why it improves the code
+- Which files will be created, modified, or deleted
+- Any import paths that will change
+- Whether the public API surface changes (it shouldn't)
+
+If the refactoring is large (touches more than 5 files), break it into incremental steps where tests pass after each step.
+
+## Phase 3: Make Changes
+
+Apply changes incrementally. After each logical step, verify nothing broke.
+
+### Import Conventions (must follow)
+
+- **In `packages/keryx/`** — use relative imports:
+  ```typescript
+  import { api } from "../api";
+  import { Action } from "../classes/Action";
+  ```
+- **In `example/backend/`** — use `"keryx"` for framework, relative for app-local:
+  ```typescript
+  import { api, Action, type ActionParams, HTTP_METHOD } from "keryx";
+  import { SessionMiddleware } from "../middleware/session";
+  ```
+
+### Code Quality Rules
+
+- No `as any` — use `@ts-expect-error` with a comment if the type system can't express something
+- JSDoc annotations on any new or modified public APIs in `packages/keryx/`
+- Don't add unnecessary abstractions — three similar lines are better than a premature helper
+- Don't add comments, docstrings, or type annotations to code you didn't change
+- If something is unused after the refactor, delete it completely — no `_unused` renames or `// removed` comments
+
+### When Extracting to New Files
+
+- Follow existing naming conventions in the target directory
+- Update any barrel exports (`.index.ts` files) if the directory uses them
+- App actions must be re-exported from `example/backend/actions/.index.ts`
+
+### When Renaming
+
+- Use grep to find ALL references before renaming — including tests, config, docs, and string literals
+- Update imports across the entire monorepo, not just the immediate directory
+
+## Phase 4: Verify
+
+1. **Run lint**:
+   ```bash
+   bun lint
+   ```
+   Fix any issues with `bun format` if needed.
+
+2. **Run tests**:
+   ```bash
+   cd packages/keryx && bun test        # if framework code changed
+   cd example/backend && bun test       # if app code changed
+   ```
+
+3. **Sanity check** — review the diff to confirm:
+   - No behavior changes snuck in
+   - No files were accidentally left behind
+   - Import paths are all correct
+   - No `as any` was introduced
+
+## Phase 5: Summarize
+
+After completing the refactoring, briefly state:
+- What changed structurally
+- How many files were modified/created/deleted
+- That tests pass
+
+Do NOT provide a lengthy recap of every line changed — the user can read the diff.

--- a/packages/keryx/__tests__/util/mcpServer.test.ts
+++ b/packages/keryx/__tests__/util/mcpServer.test.ts
@@ -1,0 +1,226 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { z } from "zod";
+import { api } from "../../api";
+import { Action, HTTP_METHOD } from "../../classes/Action";
+import { config } from "../../config";
+import { HOOK_TIMEOUT, serverUrl } from "../setup";
+
+const mcpUrl = () => `${serverUrl()}${config.server.mcp.route}`;
+
+/**
+ * Temporary test action that exposes an MCP resource via URI template.
+ * Registered before tests and removed after.
+ */
+class TestTemplateResource extends Action {
+  constructor() {
+    super({
+      name: "test:template-resource",
+      description: "Test resource with URI template variables",
+      inputs: z.object({
+        name: z.string().describe("A name variable from the URI template"),
+      }),
+      mcp: {
+        tool: false,
+        resource: {
+          uriTemplate: "keryx://test-greeting/{name}",
+          mimeType: "text/plain",
+        },
+      },
+      web: { route: "/test-template-resource/:name", method: HTTP_METHOD.GET },
+    });
+  }
+
+  async run(params: { name: string }) {
+    return { text: `Hello, ${params.name}!` };
+  }
+}
+
+/**
+ * Temporary test action that exposes an MCP prompt.
+ * Registered before tests and removed after.
+ */
+class TestPrompt extends Action {
+  constructor() {
+    super({
+      name: "test:prompt",
+      description: "Test prompt with arguments",
+      inputs: z.object({
+        topic: z.string().optional().describe("Topic to discuss"),
+      }),
+      mcp: {
+        tool: false,
+        prompt: { title: "Test Prompt" },
+      },
+      web: { route: "/test-prompt", method: HTTP_METHOD.GET },
+    });
+  }
+
+  async run(params: { topic?: string }) {
+    return {
+      description: "A test prompt",
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Let's talk about ${params.topic ?? "anything"}.`,
+          },
+        },
+      ],
+    };
+  }
+}
+
+describe("mcpServer utilities (integration)", () => {
+  const testActions: Action[] = [];
+
+  beforeAll(async () => {
+    config.server.mcp.enabled = true;
+    await api.start();
+
+    // Inject test actions after start (api.actions is now populated).
+    // MCP servers are created per-session, so these will be picked up
+    // when the test client connects.
+    const templateResource = new TestTemplateResource();
+    const prompt = new TestPrompt();
+    testActions.push(templateResource, prompt);
+    api.actions.actions.push(...testActions);
+  }, HOOK_TIMEOUT);
+
+  afterAll(async () => {
+    await api.stop();
+    config.server.mcp.enabled = false;
+
+    // Remove injected test actions
+    for (const action of testActions) {
+      const idx = api.actions.actions.indexOf(action);
+      if (idx !== -1) api.actions.actions.splice(idx, 1);
+    }
+  }, HOOK_TIMEOUT);
+
+  describe("URI template resources", () => {
+    // MCP requires auth — get a token via the OAuth initializer
+    let accessToken: string;
+
+    beforeAll(async () => {
+      // Store a token directly in Redis to avoid the full OAuth flow
+      accessToken = crypto.randomUUID();
+      await api.redis.redis.set(
+        `oauth:token:${accessToken}`,
+        JSON.stringify({ userId: 0, clientId: "test", scopes: [] }),
+        "EX",
+        60,
+      );
+    });
+
+    afterEach(async () => {
+      // Clean up session keys created during tests
+      const keys = await api.redis.redis.keys("session:*");
+      if (keys.length > 0) await api.redis.redis.del(...keys);
+    });
+
+    test("listResourceTemplates includes URI template resource", async () => {
+      const transport = new StreamableHTTPClientTransport(new URL(mcpUrl()), {
+        requestInit: {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      });
+      const client = new Client({ name: "test", version: "1.0.0" });
+      await client.connect(transport);
+
+      try {
+        const result = await client.listResourceTemplates();
+        const uris = result.resourceTemplates.map((r) => r.uriTemplate);
+        expect(uris).toContain("keryx://test-greeting/{name}");
+      } finally {
+        try {
+          await transport.close();
+        } catch {
+          // ignore
+        }
+      }
+    });
+
+    test("reading a URI template resource passes variables to the action", async () => {
+      const transport = new StreamableHTTPClientTransport(new URL(mcpUrl()), {
+        requestInit: {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      });
+      const client = new Client({ name: "test", version: "1.0.0" });
+      await client.connect(transport);
+
+      try {
+        const result = await client.readResource({
+          uri: "keryx://test-greeting/World",
+        });
+        expect(result.contents).toBeArray();
+        expect(result.contents.length).toBe(1);
+
+        const content = result.contents[0];
+        expect(content.uri).toBe("keryx://test-greeting/World");
+        expect(content.mimeType).toBe("text/plain");
+        expect((content as { text: string }).text).toBe("Hello, World!");
+      } finally {
+        try {
+          await transport.close();
+        } catch {
+          // ignore
+        }
+      }
+    });
+  });
+
+  describe("prompt registration", () => {
+    let accessToken: string;
+
+    beforeAll(async () => {
+      accessToken = crypto.randomUUID();
+      await api.redis.redis.set(
+        `oauth:token:${accessToken}`,
+        JSON.stringify({ userId: 0, clientId: "test", scopes: [] }),
+        "EX",
+        60,
+      );
+    });
+
+    test("prompt with arguments returns expected messages", async () => {
+      const transport = new StreamableHTTPClientTransport(new URL(mcpUrl()), {
+        requestInit: {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      });
+      const client = new Client({ name: "test", version: "1.0.0" });
+      await client.connect(transport);
+
+      try {
+        const result = await client.getPrompt({
+          name: "test-prompt",
+          arguments: { topic: "refactoring" },
+        });
+        expect(result.messages).toBeArray();
+        expect(result.messages.length).toBe(1);
+        const msg = result.messages[0];
+        expect(msg.role).toBe("user");
+        expect((msg.content as { type: string; text: string }).text).toContain(
+          "refactoring",
+        );
+      } finally {
+        try {
+          await transport.close();
+        } catch {
+          // ignore
+        }
+      }
+    });
+  });
+});

--- a/packages/keryx/initializers/mcp.ts
+++ b/packages/keryx/initializers/mcp.ts
@@ -1,26 +1,21 @@
-import {
-  McpServer,
-  ResourceTemplate,
-} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import colors from "colors";
 import { randomUUID } from "crypto";
-import * as z4mini from "zod/v4-mini";
 import { api, logger } from "../api";
-import type { Action } from "../classes/Action";
-import { MCP_RESPONSE_FORMAT } from "../classes/Action";
-import { Connection } from "../classes/Connection";
 import { Initializer } from "../classes/Initializer";
-import { StreamingResponse } from "../classes/StreamingResponse";
 import { ErrorType, TypedError } from "../classes/TypedError";
 import { config } from "../config";
-import pkg from "../package.json";
+import { buildCorsHeaders, getExternalOrigin } from "../util/http";
 import {
-  appendHeaders,
-  buildCorsHeaders,
-  getExternalOrigin,
-} from "../util/http";
-import { toMarkdown } from "../util/toMarkdown";
+  createMcpServer,
+  formatToolName,
+  handleTransportRequest,
+  type McpAuthInfo,
+  mcpJsonResponse,
+  parseToolName,
+  sanitizeSchemaForMcp,
+} from "../util/mcpServer";
 import type { PubSubMessage } from "./pubsub";
 
 type McpHandleRequest = (req: Request, ip: string) => Promise<Response>;
@@ -31,25 +26,6 @@ declare module "../classes/API" {
   export interface API {
     [namespace]: Awaited<ReturnType<McpInitializer["initialize"]>>;
   }
-}
-
-/**
- * Convert a Keryx action name to a valid MCP tool name.
- * MCP tool names only allow: A-Z, a-z, 0-9, underscore (_), dash (-), and dot (.)
- */
-function formatToolName(actionName: string): string {
-  return actionName.replace(/:/g, "-");
-}
-
-/**
- * Convert an MCP tool name back to the original Keryx action name.
- */
-function parseToolName(toolName: string): string {
-  // Reverse lookup against registered actions
-  const action = api.actions.actions.find(
-    (a: Action) => formatToolName(a.name) === toolName,
-  );
-  return action ? action.name : toolName;
 }
 
 export class McpInitializer extends Initializer {
@@ -104,7 +80,7 @@ export class McpInitializer extends Initializer {
 
     const mcpRoute = config.server.mcp.route;
 
-    // 1. Route validation
+    // Route validation
     if (!mcpRoute.startsWith("/")) {
       throw new TypedError({
         message: `MCP route must start with "/", got: ${mcpRoute}`,
@@ -132,7 +108,7 @@ export class McpInitializer extends Initializer {
       }
     }
 
-    // 2. Build handleRequest — each new session creates a fresh McpServer
+    // Build handleRequest — each new session creates a fresh McpServer
     const transports = api.mcp.transports;
     const mcpServers = api.mcp.mcpServers;
 
@@ -155,15 +131,10 @@ export class McpInitializer extends Initializer {
         if (appUrl && !appUrl.startsWith("http://localhost")) {
           const allowedOrigin = new URL(appUrl).origin;
           if (requestOrigin !== allowedOrigin) {
-            return new Response(
-              JSON.stringify({ error: "Origin not allowed" }),
-              {
-                status: 403,
-                headers: {
-                  "Content-Type": "application/json",
-                  ...corsHeaders,
-                },
-              },
+            return mcpJsonResponse(
+              { error: "Origin not allowed" },
+              403,
+              corsHeaders,
             );
           }
         }
@@ -175,21 +146,11 @@ export class McpInitializer extends Initializer {
       }
 
       if (method !== "GET" && method !== "POST" && method !== "DELETE") {
-        return new Response(null, {
-          status: 405,
-          headers: corsHeaders,
-        });
+        return new Response(null, { status: 405, headers: corsHeaders });
       }
 
       // Extract and verify Bearer token for auth
-      let authInfo:
-        | {
-            token: string;
-            clientId: string;
-            scopes: string[];
-            extra?: Record<string, unknown>;
-          }
-        | undefined;
+      let authInfo: McpAuthInfo | undefined;
       const authHeader = req.headers.get("authorization");
       if (authHeader?.startsWith("Bearer ")) {
         const token = authHeader.slice(7);
@@ -208,15 +169,12 @@ export class McpInitializer extends Initializer {
       if (!authInfo) {
         const origin = getExternalOrigin(req, new URL(req.url));
         const resourceMetadataUrl = `${origin}/.well-known/oauth-protected-resource${config.server.mcp.route}`;
-        return new Response(
-          JSON.stringify({ error: "Authentication required" }),
+        return mcpJsonResponse(
+          { error: "Authentication required" },
+          401,
+          corsHeaders,
           {
-            status: 401,
-            headers: {
-              "Content-Type": "application/json",
-              "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
-              ...corsHeaders,
-            },
+            "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
           },
         );
       }
@@ -252,72 +210,27 @@ export class McpInitializer extends Initializer {
 
         await mcpServer.connect(transport);
 
-        try {
-          const response = await transport.handleRequest(req, { authInfo });
-          return appendHeaders(response, corsHeaders);
-        } catch (e) {
-          logger.error(`MCP transport error: ${e}`);
-          return new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              error: { code: -32603, message: "Internal server error" },
-              id: null,
-            }),
-            {
-              status: 500,
-              headers: {
-                "Content-Type": "application/json",
-                ...corsHeaders,
-              },
-            },
-          );
-        }
+        return handleTransportRequest(transport, req, authInfo, corsHeaders);
       }
 
       if (sessionId) {
         const transport = transports.get(sessionId);
         if (!transport) {
-          return new Response(JSON.stringify({ error: "Session not found" }), {
-            status: 404,
-            headers: {
-              "Content-Type": "application/json",
-              ...corsHeaders,
-            },
-          });
-        }
-
-        try {
-          const response = await transport.handleRequest(req, { authInfo });
-          return appendHeaders(response, corsHeaders);
-        } catch (e) {
-          logger.error(`MCP transport error: ${e}`);
-          return new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              error: { code: -32603, message: "Internal server error" },
-              id: null,
-            }),
-            {
-              status: 500,
-              headers: {
-                "Content-Type": "application/json",
-                ...corsHeaders,
-              },
-            },
+          return mcpJsonResponse(
+            { error: "Session not found" },
+            404,
+            corsHeaders,
           );
         }
+
+        return handleTransportRequest(transport, req, authInfo, corsHeaders);
       }
 
       // GET/DELETE without session ID
-      return new Response(
-        JSON.stringify({ error: "Mcp-Session-Id header required" }),
-        {
-          status: 400,
-          headers: {
-            "Content-Type": "application/json",
-            ...corsHeaders,
-          },
-        },
+      return mcpJsonResponse(
+        { error: "Mcp-Session-Id header required" },
+        400,
+        corsHeaders,
       );
     };
 
@@ -351,319 +264,4 @@ export class McpInitializer extends Initializer {
 
     api.mcp.handleRequest = null;
   }
-}
-
-/**
- * Create a new McpServer instance with all actions registered as tools, resources, and prompts.
- * Each MCP session gets its own McpServer (the SDK requires 1:1 mapping).
- * Actions with `mcp.tool === false` are excluded from tool registration.
- */
-function createMcpServer(): McpServer {
-  const mcpServer = new McpServer(
-    { name: pkg.name, version: pkg.version },
-    { instructions: config.server.mcp.instructions },
-  );
-
-  for (const action of api.actions.actions) {
-    if (action.mcp?.tool === false) continue;
-
-    const toolName = formatToolName(action.name);
-    const toolConfig: {
-      description?: string;
-      inputSchema?: any;
-    } = {};
-
-    if (action.description) {
-      toolConfig.description = action.description;
-    }
-
-    toolConfig.inputSchema = action.inputs
-      ? sanitizeSchemaForMcp(action.inputs)
-      : z4mini.strictObject({});
-
-    mcpServer.registerTool(
-      toolName,
-      toolConfig,
-      async (args: any, extra: any) => {
-        const authInfo = extra.authInfo;
-
-        const clientIp = (authInfo?.extra?.ip as string) || "unknown";
-        const mcpSessionId = extra.sessionId || "";
-        const connection = new Connection(
-          "mcp",
-          clientIp,
-          randomUUID(),
-          undefined,
-          authInfo?.token,
-        );
-
-        try {
-          // If Bearer token was verified, set up authenticated session
-          if (authInfo?.extra?.userId) {
-            await connection.loadSession();
-            await connection.updateSession({ userId: authInfo.extra.userId });
-          }
-
-          const params =
-            args && typeof args === "object"
-              ? (args as Record<string, unknown>)
-              : {};
-
-          const { response, error } = await connection.act(
-            action.name,
-            params,
-            "",
-            mcpSessionId,
-          );
-
-          // Errors always use JSON for programmatic handling
-          if (error) {
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify({
-                    error: error.message,
-                    type: error.type,
-                  }),
-                },
-              ],
-              isError: true,
-            };
-          }
-
-          // For streaming responses, consume the stream and accumulate into a single result.
-          // Send incremental chunks as MCP logging messages for real-time visibility.
-          if (response instanceof StreamingResponse) {
-            const reader = response.stream.getReader();
-            const decoder = new TextDecoder();
-            let accumulated = "";
-            try {
-              while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                const chunk = decoder.decode(value);
-                accumulated += chunk;
-                try {
-                  mcpServer.server.sendLoggingMessage({
-                    level: "info",
-                    data: chunk,
-                  });
-                } catch (_e) {
-                  // Logging message delivery is best-effort
-                }
-              }
-            } finally {
-              response.onClose?.();
-            }
-            return {
-              content: [{ type: "text" as const, text: accumulated }],
-            };
-          }
-
-          const format = action.mcp?.responseFormat ?? MCP_RESPONSE_FORMAT.JSON;
-          const text =
-            format === MCP_RESPONSE_FORMAT.MARKDOWN
-              ? toMarkdown(response, {
-                  maxDepth: config.server.mcp.markdownDepthLimit,
-                })
-              : JSON.stringify(response);
-
-          return {
-            content: [{ type: "text" as const, text }],
-          };
-        } finally {
-          connection.destroy();
-        }
-      },
-    );
-  }
-
-  // Register actions as MCP resources
-  for (const action of api.actions.actions) {
-    if (!action.mcp?.resource) continue;
-    const { uri, uriTemplate, mimeType } = action.mcp.resource;
-
-    const readCb = async (
-      mcpUri: URL,
-      variables: Record<string, string | string[]>,
-      extra: any,
-    ) => {
-      const authInfo = extra.authInfo;
-      const clientIp = (authInfo?.extra?.ip as string) || "unknown";
-      const mcpSessionId = extra.sessionId || "";
-      const connection = new Connection(
-        "mcp",
-        clientIp,
-        randomUUID(),
-        undefined,
-        authInfo?.token,
-      );
-
-      try {
-        if (authInfo?.extra?.userId) {
-          await connection.loadSession();
-          await connection.updateSession({ userId: authInfo.extra.userId });
-        }
-
-        const params: Record<string, unknown> = { ...variables };
-        const { response, error } = await connection.act(
-          action.name,
-          params,
-          "",
-          mcpSessionId,
-        );
-
-        if (error) {
-          throw new TypedError({
-            message: error.message,
-            type: error.type ?? ErrorType.CONNECTION_ACTION_RUN,
-          });
-        }
-
-        const content = response as {
-          text?: string;
-          blob?: string;
-          mimeType?: string;
-        };
-        const resolvedMimeType =
-          content.mimeType ?? mimeType ?? "application/json";
-
-        return {
-          contents: [
-            {
-              uri: mcpUri.toString(),
-              mimeType: resolvedMimeType,
-              ...(content.blob
-                ? { blob: content.blob }
-                : {
-                    text:
-                      typeof content.text === "string"
-                        ? content.text
-                        : JSON.stringify(response),
-                  }),
-            },
-          ],
-        };
-      } finally {
-        connection.destroy();
-      }
-    };
-
-    if (uriTemplate) {
-      mcpServer.registerResource(
-        formatToolName(action.name),
-        new ResourceTemplate(uriTemplate, { list: undefined }),
-        { description: action.description, mimeType },
-        readCb,
-      );
-    } else if (uri) {
-      mcpServer.registerResource(
-        formatToolName(action.name),
-        uri,
-        { description: action.description, mimeType },
-        (mcpUri: URL, extra: any) => readCb(mcpUri, {}, extra),
-      );
-    }
-  }
-
-  // Register actions as MCP prompts
-  for (const action of api.actions.actions) {
-    if (!action.mcp?.prompt) continue;
-    const { title } = action.mcp.prompt;
-
-    mcpServer.registerPrompt(
-      formatToolName(action.name),
-      {
-        title: title ?? action.name,
-        description: action.description,
-        // argsSchema expects a Record<string, ZodType> (the shape), not a z.object()
-        argsSchema: action.inputs
-          ? sanitizeSchemaForMcp(action.inputs)?.shape
-          : undefined,
-      },
-      async (args: any, extra: any) => {
-        const authInfo = extra.authInfo;
-        const clientIp = (authInfo?.extra?.ip as string) || "unknown";
-        const mcpSessionId = extra.sessionId || "";
-        const connection = new Connection(
-          "mcp",
-          clientIp,
-          randomUUID(),
-          undefined,
-          authInfo?.token,
-        );
-
-        try {
-          if (authInfo?.extra?.userId) {
-            await connection.loadSession();
-            await connection.updateSession({ userId: authInfo.extra.userId });
-          }
-
-          const params =
-            args && typeof args === "object"
-              ? (args as Record<string, unknown>)
-              : {};
-
-          const { response, error } = await connection.act(
-            action.name,
-            params,
-            "",
-            mcpSessionId,
-          );
-
-          if (error) {
-            throw new TypedError({
-              message: error.message,
-              type: error.type ?? ErrorType.CONNECTION_ACTION_RUN,
-            });
-          }
-
-          return response as any;
-        } finally {
-          connection.destroy();
-        }
-      },
-    );
-  }
-
-  return mcpServer;
-}
-
-/**
- * Sanitize a Zod object schema for MCP tool registration.
- * The MCP SDK's internal JSON Schema converter (zod/v4-mini toJSONSchema)
- * cannot handle certain Zod types like z.date(). This function tests each
- * field individually and replaces incompatible fields with z.string().
- */
-function sanitizeSchemaForMcp(schema: any): any {
-  if (!schema || typeof schema !== "object" || !("shape" in schema)) {
-    return schema;
-  }
-
-  // Empty object schemas should use strictObject to produce
-  // { type: "object", additionalProperties: false } per MCP spec
-  if (Object.entries(schema.shape as Record<string, any>).length === 0) {
-    return z4mini.strictObject({});
-  }
-
-  const newShape: Record<string, any> = {};
-  let needsSanitization = false;
-
-  for (const [key, fieldSchema] of Object.entries(
-    schema.shape as Record<string, any>,
-  )) {
-    try {
-      z4mini.toJSONSchema(z4mini.object({ [key]: fieldSchema }), {
-        target: "draft-7",
-        io: "input",
-      });
-      newShape[key] = fieldSchema;
-    } catch {
-      needsSanitization = true;
-      newShape[key] = z4mini.string();
-    }
-  }
-
-  return needsSanitization ? z4mini.object(newShape) : schema;
 }

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/mcpServer.ts
+++ b/packages/keryx/util/mcpServer.ts
@@ -1,0 +1,398 @@
+import {
+  McpServer,
+  ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { randomUUID } from "crypto";
+import * as z4mini from "zod/v4-mini";
+import { api, logger } from "../api";
+import type { Action } from "../classes/Action";
+import { MCP_RESPONSE_FORMAT } from "../classes/Action";
+import { Connection } from "../classes/Connection";
+import { StreamingResponse } from "../classes/StreamingResponse";
+import { ErrorType, TypedError } from "../classes/TypedError";
+import { config } from "../config";
+import pkg from "../package.json";
+import { appendHeaders } from "../util/http";
+import { toMarkdown } from "../util/toMarkdown";
+
+/**
+ * Convert a Keryx action name to a valid MCP tool name.
+ * MCP tool names only allow: A-Z, a-z, 0-9, underscore (_), dash (-), and dot (.)
+ */
+export function formatToolName(actionName: string): string {
+  return actionName.replace(/:/g, "-");
+}
+
+/**
+ * Convert an MCP tool name back to the original Keryx action name.
+ */
+export function parseToolName(toolName: string): string {
+  const action = api.actions.actions.find(
+    (a: Action) => formatToolName(a.name) === toolName,
+  );
+  return action ? action.name : toolName;
+}
+
+/**
+ * Auth info extracted from a Bearer token on an MCP request.
+ */
+export type McpAuthInfo = {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  extra?: Record<string, unknown>;
+};
+
+/**
+ * Create an authenticated MCP Connection from the auth info attached to an MCP request.
+ * Shared by tool, resource, and prompt handlers to avoid duplicating connection setup.
+ */
+export async function createMcpConnection(extra: {
+  authInfo?: McpAuthInfo;
+  sessionId?: string;
+}): Promise<Connection> {
+  const authInfo = extra.authInfo;
+  const clientIp = (authInfo?.extra?.ip as string) || "unknown";
+  const connection = new Connection(
+    "mcp",
+    clientIp,
+    randomUUID(),
+    undefined,
+    authInfo?.token,
+  );
+
+  if (authInfo?.extra?.userId) {
+    await connection.loadSession();
+    await connection.updateSession({ userId: authInfo.extra.userId });
+  }
+
+  return connection;
+}
+
+/**
+ * Forward a request to an MCP transport and return the response with CORS headers.
+ * Handles the try/catch + error response pattern shared by new-session and existing-session paths.
+ */
+export async function handleTransportRequest(
+  transport: WebStandardStreamableHTTPServerTransport,
+  req: Request,
+  authInfo: McpAuthInfo | undefined,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  try {
+    const response = await transport.handleRequest(req, { authInfo });
+    return appendHeaders(response, corsHeaders);
+  } catch (e) {
+    logger.error(`MCP transport error: ${e}`);
+    return mcpJsonResponse(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      },
+      500,
+      corsHeaders,
+    );
+  }
+}
+
+/**
+ * Build a JSON Response with CORS headers. Reduces boilerplate across
+ * the many error/status responses in the MCP request handler.
+ */
+export function mcpJsonResponse(
+  body: unknown,
+  status: number,
+  corsHeaders: Record<string, string>,
+  extraHeaders?: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...corsHeaders,
+      ...extraHeaders,
+    },
+  });
+}
+
+/**
+ * Create a new McpServer instance with all actions registered as tools, resources, and prompts.
+ * Each MCP session gets its own McpServer (the SDK requires 1:1 mapping).
+ * Actions with `mcp.tool === false` are excluded from tool registration.
+ */
+export function createMcpServer(): McpServer {
+  const mcpServer = new McpServer(
+    { name: pkg.name, version: pkg.version },
+    { instructions: config.server.mcp.instructions },
+  );
+
+  registerTools(mcpServer);
+  registerResources(mcpServer);
+  registerPrompts(mcpServer);
+
+  return mcpServer;
+}
+
+function registerTools(mcpServer: McpServer) {
+  for (const action of api.actions.actions) {
+    if (action.mcp?.tool === false) continue;
+
+    const toolName = formatToolName(action.name);
+    const toolConfig: {
+      description?: string;
+      inputSchema?: any;
+    } = {};
+
+    if (action.description) {
+      toolConfig.description = action.description;
+    }
+
+    toolConfig.inputSchema = action.inputs
+      ? sanitizeSchemaForMcp(action.inputs)
+      : z4mini.strictObject({});
+
+    mcpServer.registerTool(
+      toolName,
+      toolConfig,
+      async (args: any, extra: any) => {
+        const mcpSessionId = extra.sessionId || "";
+        const connection = await createMcpConnection(extra);
+
+        try {
+          const params =
+            args && typeof args === "object"
+              ? (args as Record<string, unknown>)
+              : {};
+
+          const { response, error } = await connection.act(
+            action.name,
+            params,
+            "",
+            mcpSessionId,
+          );
+
+          if (error) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    error: error.message,
+                    type: error.type,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          // For streaming responses, consume the stream and accumulate into a single result.
+          // Send incremental chunks as MCP logging messages for real-time visibility.
+          if (response instanceof StreamingResponse) {
+            const reader = response.stream.getReader();
+            const decoder = new TextDecoder();
+            let accumulated = "";
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                const chunk = decoder.decode(value);
+                accumulated += chunk;
+                try {
+                  mcpServer.server.sendLoggingMessage({
+                    level: "info",
+                    data: chunk,
+                  });
+                } catch (_e) {
+                  // Logging message delivery is best-effort
+                }
+              }
+            } finally {
+              response.onClose?.();
+            }
+            return {
+              content: [{ type: "text" as const, text: accumulated }],
+            };
+          }
+
+          const format = action.mcp?.responseFormat ?? MCP_RESPONSE_FORMAT.JSON;
+          const text =
+            format === MCP_RESPONSE_FORMAT.MARKDOWN
+              ? toMarkdown(response, {
+                  maxDepth: config.server.mcp.markdownDepthLimit,
+                })
+              : JSON.stringify(response);
+
+          return {
+            content: [{ type: "text" as const, text }],
+          };
+        } finally {
+          connection.destroy();
+        }
+      },
+    );
+  }
+}
+
+function registerResources(mcpServer: McpServer) {
+  for (const action of api.actions.actions) {
+    if (!action.mcp?.resource) continue;
+    const { uri, uriTemplate, mimeType } = action.mcp.resource;
+
+    const readCb = async (
+      mcpUri: URL,
+      variables: Record<string, string | string[]>,
+      extra: any,
+    ) => {
+      const mcpSessionId = extra.sessionId || "";
+      const connection = await createMcpConnection(extra);
+
+      try {
+        const params: Record<string, unknown> = { ...variables };
+        const { response, error } = await connection.act(
+          action.name,
+          params,
+          "",
+          mcpSessionId,
+        );
+
+        if (error) {
+          throw new TypedError({
+            message: error.message,
+            type: error.type ?? ErrorType.CONNECTION_ACTION_RUN,
+          });
+        }
+
+        const content = response as {
+          text?: string;
+          blob?: string;
+          mimeType?: string;
+        };
+        const resolvedMimeType =
+          content.mimeType ?? mimeType ?? "application/json";
+
+        return {
+          contents: [
+            {
+              uri: mcpUri.toString(),
+              mimeType: resolvedMimeType,
+              ...(content.blob
+                ? { blob: content.blob }
+                : {
+                    text:
+                      typeof content.text === "string"
+                        ? content.text
+                        : JSON.stringify(response),
+                  }),
+            },
+          ],
+        };
+      } finally {
+        connection.destroy();
+      }
+    };
+
+    if (uriTemplate) {
+      mcpServer.registerResource(
+        formatToolName(action.name),
+        new ResourceTemplate(uriTemplate, { list: undefined }),
+        { description: action.description, mimeType },
+        readCb,
+      );
+    } else if (uri) {
+      mcpServer.registerResource(
+        formatToolName(action.name),
+        uri,
+        { description: action.description, mimeType },
+        (mcpUri: URL, extra: any) => readCb(mcpUri, {}, extra),
+      );
+    }
+  }
+}
+
+function registerPrompts(mcpServer: McpServer) {
+  for (const action of api.actions.actions) {
+    if (!action.mcp?.prompt) continue;
+    const { title } = action.mcp.prompt;
+
+    mcpServer.registerPrompt(
+      formatToolName(action.name),
+      {
+        title: title ?? action.name,
+        description: action.description,
+        argsSchema: action.inputs
+          ? sanitizeSchemaForMcp(action.inputs)?.shape
+          : undefined,
+      },
+      async (args: any, extra: any) => {
+        const mcpSessionId = extra.sessionId || "";
+        const connection = await createMcpConnection(extra);
+
+        try {
+          const params =
+            args && typeof args === "object"
+              ? (args as Record<string, unknown>)
+              : {};
+
+          const { response, error } = await connection.act(
+            action.name,
+            params,
+            "",
+            mcpSessionId,
+          );
+
+          if (error) {
+            throw new TypedError({
+              message: error.message,
+              type: error.type ?? ErrorType.CONNECTION_ACTION_RUN,
+            });
+          }
+
+          return response as any;
+        } finally {
+          connection.destroy();
+        }
+      },
+    );
+  }
+}
+
+/**
+ * Sanitize a Zod object schema for MCP tool registration.
+ * The MCP SDK's internal JSON Schema converter (zod/v4-mini toJSONSchema)
+ * cannot handle certain Zod types like z.date(). This function tests each
+ * field individually and replaces incompatible fields with z.string().
+ */
+export function sanitizeSchemaForMcp(schema: any): any {
+  if (!schema || typeof schema !== "object" || !("shape" in schema)) {
+    return schema;
+  }
+
+  // Empty object schemas should use strictObject to produce
+  // { type: "object", additionalProperties: false } per MCP spec
+  if (Object.entries(schema.shape as Record<string, any>).length === 0) {
+    return z4mini.strictObject({});
+  }
+
+  const newShape: Record<string, any> = {};
+  let needsSanitization = false;
+
+  for (const [key, fieldSchema] of Object.entries(
+    schema.shape as Record<string, any>,
+  )) {
+    try {
+      z4mini.toJSONSchema(z4mini.object({ [key]: fieldSchema }), {
+        target: "draft-7",
+        io: "input",
+      });
+      newShape[key] = fieldSchema;
+    } catch {
+      needsSanitization = true;
+      newShape[key] = z4mini.string();
+    }
+  }
+
+  return needsSanitization ? z4mini.object(newShape) : schema;
+}


### PR DESCRIPTION
## Summary

- Extract `createMcpServer`, `sanitizeSchemaForMcp`, `formatToolName`, `parseToolName` from `initializers/mcp.ts` into `util/mcpServer.ts`
- Add shared helpers (`createMcpConnection`, `handleTransportRequest`, `mcpJsonResponse`) that deduplicate repeated patterns across tool/resource/prompt registration and HTTP request handling
- Shrinks `initializers/mcp.ts` from ~670 to ~265 lines — now focused on lifecycle management only
- Add framework-level integration tests for URI template resources and prompt registration (`__tests__/util/mcpServer.test.ts`)
- No public API changes

## Test plan

- [x] All 370 framework tests pass (3 new)
- [x] All 47 example MCP integration tests pass
- [x] Lint clean across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)