### PR TITLE
Add llms.txt link to Built for AI Agents section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -154,6 +154,7 @@ Keryx is the only TypeScript framework where your API is automatically an MCP se
 - **Per-session MCP servers** — each agent connection gets isolated state. No cross-session leaks.
 - **Typed errors** — agents get structured `ErrorType` values, not generic failure messages. They can distinguish validation errors from auth failures.
 - **Real-time notifications** — PubSub events are forwarded to connected agents as MCP logging messages.
+- **`llms.txt` included** — AI agents and LLMs can discover optimized Markdown documentation at [`/llms.txt`](/llms.txt), no scraping needed.
 
 Claude Desktop, VS Code Copilot, Cursor, Windsurf, and any other MCP client can discover and call your actions out of the box.
 


### PR DESCRIPTION
## Summary
- Adds an `llms.txt` bullet point to the "Built for AI Agents" section on the landing page
- Complements the hero CTA button added in #311 — the link is now discoverable in both the hero and the AI features section

Closes #304

## Test plan
- [ ] `bun docs:dev` — verify the new bullet renders correctly in the "Built for AI Agents" section
- [ ] Confirm the `/llms.txt` link navigates to the generated LLM documentation index

🤖 Generated with [Claude Code](https://claude.com/claude-code)