### PR TITLE
Bump version to 0.21.2

### DIFF
--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps package version from 0.21.1 to 0.21.2 to trigger a new publish covering the MCP OAuth metadata fix (#336) and Render deployment updates.

## Test plan
- [ ] Verify `packages/keryx/package.json` shows version `0.21.2`
- [ ] Confirm publish workflow triggers on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)